### PR TITLE
Remove internal header from reassembly

### DIFF
--- a/include/quicrq_reassembly.h
+++ b/include/quicrq_reassembly.h
@@ -2,7 +2,6 @@
 #define QUICRQ_REASSEMBLY_H
 
 #include "quicrq.h"
-#include "quicrq_internal.h"
 #include "picoquic_utils.h"
 #include "picosplay.h"
 


### PR DESCRIPTION
This should fix issue #28, by removing the reference to "quicrq_internal.h" from "quicrq_reassembly.h". @suhasHere, please tell me whether that works for you.