### PR TITLE
flag for in order delivery

### DIFF
--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -246,13 +246,13 @@ typedef int (*quicrq_object_stream_consumer_fn)(
     size_t data_length,
     quicrq_object_stream_consumer_properties_t* properties);
 
-typedef struct st_quicrq_object_consumer_bridge_ctx_t quicrq_object_consumer_bridge_ctx_t;
+typedef struct st_quicrq_object_stream_consumer_ctx quicrq_object_stream_consumer_ctx;
 
-quicrq_object_consumer_bridge_ctx_t* quicrq_subscribe_object_stream(quicrq_cnx_ctx_t* cnx_ctx,
-    const uint8_t* url, size_t url_length, int use_datagrams,
+quicrq_object_stream_consumer_ctx* quicrq_subscribe_object_stream(quicrq_cnx_ctx_t* cnx_ctx,
+    const uint8_t* url, size_t url_length, int use_datagrams, int in_order_required,
     quicrq_object_stream_consumer_fn media_object_consumer_fn, void* media_object_ctx);
 
-void quicrq_unsubscribe_object_stream(quicrq_object_consumer_bridge_ctx_t* subscribe_ctx);
+void quicrq_unsubscribe_object_stream(quicrq_object_stream_consumer_ctx* subscribe_ctx);
 
  /* Quic media consumer.
   * The application sets a "media consumer function" and a "media consumer context" for

--- a/lib/object_consumer.c
+++ b/lib/object_consumer.c
@@ -15,13 +15,14 @@
 #include "quicrq_reassembly.h"
 #include "picoquic_utils.h"
 
-typedef struct st_quicrq_object_consumer_bridge_ctx_t {
+typedef struct st_quicrq_object_stream_consumer_ctx {
     quicrq_ctx_t* qr_ctx;
     quicrq_stream_ctx_t* stream_ctx;
     quicrq_reassembly_context_t reassembly_ctx;
     quicrq_object_stream_consumer_fn object_stream_consumer_fn;
     void * object_stream_consumer_ctx;
-} quicrq_object_consumer_bridge_ctx_t;
+    int in_order_required;
+} quicrq_object_stream_consumer_ctx;
 
 
 /* Process fragments arriving to the bridge */
@@ -34,12 +35,13 @@ int quicrq_media_object_bridge_ready(
     quicrq_reassembly_object_mode_enum object_mode)
 {
     int ret = 0;
-    quicrq_object_consumer_bridge_ctx_t* bridge_ctx = (quicrq_object_consumer_bridge_ctx_t*)media_ctx;
+    quicrq_object_stream_consumer_ctx* bridge_ctx = (quicrq_object_stream_consumer_ctx*)media_ctx;
 
     /* TODO: for some streams, we may be able to "jump ahead" and
         * use the latest object without waiting for the full sequence */
     /* if in sequence, deliver the object to the application. */
-    if (object_mode != quicrq_reassembly_object_peek) {
+    if ((bridge_ctx->in_order_required && object_mode != quicrq_reassembly_object_peek) ||
+        (!bridge_ctx->in_order_required && object_mode != quicrq_reassembly_object_repair)){
         /* Deliver to the application */
         ret = bridge_ctx->object_stream_consumer_fn(
             quicrq_media_datagram_ready,
@@ -63,7 +65,7 @@ int quicrq_media_object_bridge_fn(
     size_t data_length)
 {
     int ret = 0;
-    quicrq_object_consumer_bridge_ctx_t* bridge_ctx = (quicrq_object_consumer_bridge_ctx_t*)media_ctx;
+    quicrq_object_stream_consumer_ctx* bridge_ctx = (quicrq_object_stream_consumer_ctx*)media_ctx;
 
     switch (action) {
     case quicrq_media_datagram_ready:
@@ -96,18 +98,19 @@ int quicrq_media_object_bridge_fn(
 }
 
 /* Subscribe object stream. */
-quicrq_object_consumer_bridge_ctx_t* quicrq_subscribe_object_stream(quicrq_cnx_ctx_t* cnx_ctx,
-    const uint8_t* url, size_t url_length, int use_datagrams,
+quicrq_object_stream_consumer_ctx* quicrq_subscribe_object_stream(quicrq_cnx_ctx_t* cnx_ctx,
+    const uint8_t* url, size_t url_length, int use_datagrams, int in_order_required,
     quicrq_object_stream_consumer_fn object_stream_consumer_fn, void* object_stream_consumer_ctx)
 {
-    quicrq_object_consumer_bridge_ctx_t* bridge_ctx = (quicrq_object_consumer_bridge_ctx_t*)malloc(sizeof(quicrq_object_consumer_bridge_ctx_t));
+    quicrq_object_stream_consumer_ctx* bridge_ctx = (quicrq_object_stream_consumer_ctx*)malloc(sizeof(quicrq_object_stream_consumer_ctx));
     if (bridge_ctx != NULL) {
         int ret;
 
-        memset(bridge_ctx, 0, sizeof(quicrq_object_consumer_bridge_ctx_t));
+        memset(bridge_ctx, 0, sizeof(quicrq_object_stream_consumer_ctx));
         bridge_ctx->qr_ctx = cnx_ctx->qr_ctx;
         bridge_ctx->object_stream_consumer_fn = object_stream_consumer_fn;
         bridge_ctx->object_stream_consumer_ctx = object_stream_consumer_ctx;
+        bridge_ctx->in_order_required = in_order_required;
         quicrq_reassembly_init(&bridge_ctx->reassembly_ctx);
         /* Create a media context for the stream */
         ret = quicrq_cnx_subscribe_media_ex(cnx_ctx, url, url_length, use_datagrams,
@@ -121,7 +124,7 @@ quicrq_object_consumer_bridge_ctx_t* quicrq_subscribe_object_stream(quicrq_cnx_c
      return bridge_ctx;
 }
 
-void quicrq_unsubscribe_object_stream(quicrq_object_consumer_bridge_ctx_t* bridge_ctx)
+void quicrq_unsubscribe_object_stream(quicrq_object_stream_consumer_ctx* bridge_ctx)
 {
     bridge_ctx->object_stream_consumer_fn = NULL;
     bridge_ctx->object_stream_consumer_ctx = NULL;

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -880,7 +880,7 @@ test_object_stream_ctx_t* test_object_stream_subscribe(quicrq_cnx_ctx_t* cnx_ctx
             ret = -1;
         }
         else {
-            cons_ctx->media_ctx = quicrq_subscribe_object_stream(cnx_ctx, url, url_length, use_datagrams, test_object_stream_consumer_cb, cons_ctx);
+            cons_ctx->media_ctx = quicrq_subscribe_object_stream(cnx_ctx, url, url_length, use_datagrams, 1, test_object_stream_consumer_cb, cons_ctx);
             if (cons_ctx->media_ctx == NULL) {
                 ret = -1;
             }


### PR DESCRIPTION
Following feedback from API review:

* add an in_order_required flag for the media object delivery
* rename `quicrq_object_consumer_bridge_ctx_t` to `quicrq_object_stream_consumer_ctx`