### PR TITLE
Changes to support using CMake with FetchContent

### DIFF
--- a/.github/workflows/test-clang.yml
+++ b/.github/workflows/test-clang.yml
@@ -24,28 +24,19 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
-          submodules: 'recursive'
 
-      - name: Build picotls and picoquic.
-        run: |
-          sudo apt-get install -y libssl-dev
-          ./ci/build_picotls.sh
-          ./ci/build_picoquic.sh
-     
       - name: Build quicrq
         run: |
-          mkdir build
-          cd build
-          cmake ..
-          cmake --build .
-          make
+          brew reinstall openssl
+          export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
+          cmake -S . -B build
+          cmake --build build
 
       - name: Perform Unit tests
         run: |
-          cd build
           ulimit -c unlimited -S
-          pwd
-          ./quicrq_t -S .. -P ../../picoquic && QRQRESULT=$? 
+          cd build
+          make test && QRQRESULT=$?
           if [ ${QRQRESULT} == 0 ]; then exit 0; fi;
           exit 1
 

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -20,26 +20,20 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
-          submodules: 'recursive'
 
-      # Build picotls and picoquic.
-      - run: |
+      - name: Build quicrq
+        run: |
           brew reinstall openssl
           export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
-          ./ci/build_picotls.sh
-          ./ci/build_picoquic.sh
-     
+          cmake -S . -B build
+          cmake --build build
+
       # Build quicrq and run tests
-      - run: |
-          mkdir build
-          cd build
-          export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
-          cmake ..
-          cmake --build .
-          make
+      - name: Perform Unit tests
+        run: |
           ulimit -c unlimited -S
-          pwd
-          ./quicrq_t -S .. -P ../../picoquic && QRQRESULT=$? 
+          cd build
+          make test && QRQRESULT=$?
           if [ ${QRQRESULT} == 0 ]; then exit 0; fi;
           exit 1
 

--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -21,28 +21,17 @@ jobs:
           # We must fetch at least the immediate parents so that if this is
           # a pull request then we can checkout the head.
           fetch-depth: 2
-          submodules: 'recursive'
 
-      - name: Build picotls and picoquic.
-        run: |
-          sudo apt-get install -y libssl-dev
-          ./ci/build_picotls.sh
-          ./ci/build_picoquic.sh
-     
       - name: Build quicrq
         run: |
-          mkdir build
-          cd build
-          cmake ..
-          cmake --build .
-          make
+          cmake -S . -B build
+          cmake --build build
 
       - name: Perform Unit tests
         run: |
-          cd build
           ulimit -c unlimited -S
-          pwd
-          ./quicrq_t -S .. -P ../../picoquic && QRQRESULT=$? 
+          cd build
+          make test && QRQRESULT=$?
           if [ ${QRQRESULT} == 0 ]; then exit 0; fi;
           exit 1
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,4 @@
-﻿################################################################################
-# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
-################################################################################
-
+﻿/build/
 /.vs/quicrq_vs/v16
 *.user
 /quicrq_lib/x64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,32 @@
-cmake_minimum_required(VERSION 2.8.11)
-cmake_policy(SET CMP0003 NEW)
-project(quicrq C CXX)
-find_package (Threads REQUIRED)
-FIND_PACKAGE(PkgConfig REQUIRED)
+cmake_minimum_required(VERSION 3.13)
 
-set(CMAKE_C_STANDARD 11)
-
-set(CMAKE_C_FLAGS "-std=c99 -Wall -Werror -O2 -g ${CC_WARNING_FLAGS} ${CMAKE_C_FLAGS}")
-
-if(DISABLE_DEBUG_PRINTF)
-    set(CMAKE_C_FLAGS "-DDISABLE_DEBUG_PRINTF ${CMAKE_C_FLAGS}")
+# Building tests by default depends on whether this is a subproject
+if(DEFINED PROJECT_NAME)
+    option(quicrq_BUILD_TESTS "Build Tests for quicrq" OFF)
+else()
+    option(quicrq_BUILD_TESTS "Build Tests for quicrq" ON)
 endif()
 
-set(QUICRQ_LIBRARY_FILES
+project(quicrq
+        VERSION 1.0.0.0
+        DESCRIPTION "quicr library"
+        LANGUAGES C CXX)
+
+
+find_package(Threads REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+# Bring in dependencies
+add_subdirectory(dependencies)
+
+find_package(OpenSSL REQUIRED)
+message(STATUS "root: ${OPENSSL_ROOT_DIR}")
+message(STATUS "OpenSSL_VERSION: ${OPENSSL_VERSION}")
+message(STATUS "OpenSSL_INCLUDE_DIR: ${OPENSSL_INCLUDE_DIR}")
+message(STATUS "OpenSSL_LIBRARIES: ${OPENSSL_LIBRARIES}")
+
+
+add_library(quicrq-core
     lib/quicrq.c
     lib/proto.c
     lib/reassembly.c
@@ -20,8 +34,19 @@ set(QUICRQ_LIBRARY_FILES
     lib/object_consumer.c
     lib/object_source.c
 )
+target_link_libraries(quicrq-core picoquic-core)
+target_include_directories(quicrq-core PUBLIC include)
+set_target_properties(quicrq-core
+    PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED YES
+        C_EXTENSIONS YES)
+target_compile_options(quicrq-core PRIVATE
+    $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Wall>
+    $<$<C_COMPILER_ID:MSVC>: >)
 
-set(QUICRQ_TEST_LIBRARY_FILES
+
+add_library(quicrq-tests
     tests/basic_test.c
     tests/fourlegs_test.c
     tests/proto_test.c
@@ -34,70 +59,85 @@ set(QUICRQ_TEST_LIBRARY_FILES
     tests/twomedia_test.c
     tests/twoways_test.c
 )
-
-set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
-
-find_package(Picoquic REQUIRED)
-message(STATUS "Picoquic/include: ${Picoquic_INCLUDE_DIRS}" )
-message(STATUS "Picoquic library: ${Picoquic_LIBRARIES}" )
-
-find_package(PTLS REQUIRED)
-message(STATUS "picotls/include: ${PTLS_INCLUDE_DIRS}" )
-message(STATUS "picotls libraries: ${PTLS_LIBRARIES}" )
-
-find_package(OpenSSL REQUIRED)
-message(STATUS "root: ${OPENSSL_ROOT_DIR}")
-message(STATUS "OpenSSL_VERSION: ${OPENSSL_VERSION}")
-message(STATUS "OpenSSL_INCLUDE_DIR: ${OPENSSL_INCLUDE_DIR}")
-message(STATUS "OpenSSL_LIBRARIES: ${OPENSSL_LIBRARIES}")
-
-include_directories(include lib tests 
-    ${Picoquic_INCLUDE_DIRS} ${PTLS_INCLUDE_DIRS} ${OPENSSL_INCLUDE_DIR})
-
-add_library(quicrq-core
-    ${QUICRQ_LIBRARY_FILES}
+target_include_directories(quicrq-tests
+    PUBLIC
+        include
+    PRIVATE
+        lib tests
 )
+target_link_libraries(quicrq-tests picoquic-core picoquic-log)
+set_target_properties(quicrq-tests
+    PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED YES
+        C_EXTENSIONS YES)
+target_compile_options(quicrq-tests PRIVATE
+    $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Wall>
+    $<$<C_COMPILER_ID:MSVC>: >)
 
-add_library(quicrq-tests
-    ${QUICRQ_TEST_LIBRARY_FILES}
+
+add_executable(quicrq_app src/quicrq_app.c)
+target_include_directories(quicrq_app
+    PUBLIC
+        include
+    PRIVATE
+        tests
 )
-
-add_executable(quicrq_app
-    src/quicrq_app.c
-)
-
 target_link_libraries(quicrq_app
+    picoquic-core
     quicrq-tests
     quicrq-core
-    ${Picoquic_LIBRARIES}
-    ${PTLS_LIBRARIES}
-    ${OPENSSL_LIBRARIES}
-    ${CMAKE_DL_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT}
+    Threads::Threads
 )
+set_target_properties(quicrq_app
+    PROPERTIES
+        C_STANDARD 11
+        C_STANDARD_REQUIRED YES
+        C_EXTENSIONS YES)
+target_compile_options(quicrq_app PRIVATE
+    $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Wall>
+    $<$<C_COMPILER_ID:MSVC>: >)
 
-add_executable(quicrq_t
-    src/quicrq_t.c
-)
 
-target_link_libraries(quicrq_t
-    quicrq-tests
-    quicrq-core
-    ${Picoquic_LIBRARIES}
-    ${PTLS_LIBRARIES}
-    ${OPENSSL_LIBRARIES}
-    ${CMAKE_DL_LIBS}
-    ${CMAKE_THREAD_LIBS_INIT}
-)
+include(CTest)
 
-set(TEST_EXES quicrq_t)
+if(BUILD_TESTING AND quicrq_BUILD_TESTS)
 
+    add_executable(quicrq_t src/quicrq_t.c)
+    target_include_directories(quicrq_t
+        PUBLIC
+            include
+        PRIVATE
+            tests)
+    target_link_libraries(quicrq_t
+        picoquic-core
+        picoquic-log
+        quicrq-tests
+        quicrq-core
+        Threads::Threads)
+    set_target_properties(quicrq_t
+        PROPERTIES
+            C_STANDARD 11
+            C_STANDARD_REQUIRED YES
+            C_EXTENSIONS YES)
+    target_compile_options(quicrq_t PRIVATE
+        $<$<OR:$<C_COMPILER_ID:Clang>,$<C_COMPILER_ID:AppleClang>,$<C_COMPILER_ID:GNU>>: -Wpedantic -Wextra -Wall>
+        $<$<C_COMPILER_ID:MSVC>: >)
+
+    add_test(NAME quicrq_t
+             COMMAND quicrq_t -S ${PROJECT_SOURCE_DIR} -P ${picoquic_SOURCE_DIR})
+
+endif()
+
+
+#
+# Adds clangformat as target that formats all source files
+#
 # get all project files for formatting
 file(GLOB_RECURSE CLANG_FORMAT_SOURCE_FILES *.c *.h)
 
-# Adds clangformat as target that formats all source files
 add_custom_target(
-    clangformat
+    quicrq_clangformat
     COMMAND clang-format
     -style=Webkit
     -i

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -1,0 +1,15 @@
+# Enable fetching content
+include(FetchContent)
+
+# Fetch the picoquic library, which brings in picotls with it
+FetchContent_Declare(
+    picoquic
+    GIT_REPOSITORY  https://github.com/private-octopus/picoquic.git
+    GIT_TAG         master
+)
+
+# Set the option to force picoquic to fetch the picotls
+set(PICOQUIC_FETCH_PTLS ON)
+
+# Make dependencies available
+FetchContent_MakeAvailable(picoquic)


### PR DESCRIPTION
Changes to support using FetchContent to satisfy all dependencies.  This needs a bit more cleanup.  See all the PEJ comments.  But, it works.