### PR TITLE
Subscribe intent

### DIFF
--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -287,12 +287,14 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+#if 0
+		/* Start point function is superceded by "receiver intent" */
 		TEST_METHOD(triangle_start_point) {
 			int ret = quicrq_triangle_start_point_test();
 
 			Assert::AreEqual(ret, 0);
 		}
-
+#endif
 		TEST_METHOD(triangle_cache) {
 			int ret = quicrq_triangle_cache_test();
 

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -299,6 +299,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_cache_loss) {
+			int ret = quicrq_triangle_cache_loss_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(triangle_cache_stream) {
 			int ret = quicrq_triangle_cache_stream_test();
 

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -337,6 +337,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_intent_next_s) {
+			int ret = quicrq_triangle_intent_next_s_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(pyramid_basic) {
 			int ret = quicrq_pyramid_basic_test();
 

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -311,6 +311,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_intent) {
+			int ret = quicrq_triangle_intent_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(pyramid_basic) {
 			int ret = quicrq_pyramid_basic_test();
 

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -325,6 +325,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_intent_loss) {
+			int ret = quicrq_triangle_intent_loss_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(pyramid_basic) {
 			int ret = quicrq_pyramid_basic_test();
 

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -343,6 +343,17 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_intent_that) {
+			int ret = quicrq_triangle_intent_that_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(triangle_intent_that_s) {
+			int ret = quicrq_triangle_intent_that_s_test();
+
+			Assert::AreEqual(ret, 0);
+		}
 		TEST_METHOD(pyramid_basic) {
 			int ret = quicrq_pyramid_basic_test();
 

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -331,6 +331,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_intent_next) {
+			int ret = quicrq_triangle_intent_next_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(pyramid_basic) {
 			int ret = quicrq_pyramid_basic_test();
 

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -288,7 +288,7 @@ namespace UnitTest
 		}
 
 #if 0
-		/* Start point function is superceded by "receiver intent" */
+		/* Start point function needs to be revised after "subscriber intent" */
 		TEST_METHOD(triangle_start_point) {
 			int ret = quicrq_triangle_start_point_test();
 
@@ -315,6 +315,12 @@ namespace UnitTest
 
 		TEST_METHOD(triangle_intent) {
 			int ret = quicrq_triangle_intent_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(triangle_intent_datagram) {
+			int ret = quicrq_triangle_intent_datagram_test();
 
 			Assert::AreEqual(ret, 0);
 		}

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -299,6 +299,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_cache_stream) {
+			int ret = quicrq_triangle_cache_stream_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(pyramid_basic) {
 			int ret = quicrq_pyramid_basic_test();
 

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -96,6 +96,7 @@ typedef struct st_quicrq_media_object_header_t {
  */
 
 typedef struct st_quicrq_media_object_source_properties_t {
+    int use_real_time_caching : 1;
     int tbd;
 } quicrq_media_object_source_properties_t;
 

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -14,7 +14,7 @@ extern "C" {
  * The minor version is updated when the protocol changes
  * Only the letter is updated if the code changes without changing the protocol
  */
-#define QUICRQ_VERSION "0.22"
+#define QUICRQ_VERSION "0.23"
 
 /* QUICR ALPN and QUICR port
  * For version zero, the ALPN is set to "quicr-h<minor>", where <minor> is
@@ -22,7 +22,7 @@ extern "C" {
  * different protocol versions will not be compatible, and connections attempts
  * between such binaries will fail, forcing deployments of compatible versions.
  */
-#define QUICRQ_ALPN "quicr-h22"
+#define QUICRQ_ALPN "quicr-h23"
 #define QUICRQ_PORT 853
 
 /* QUICR error codes */

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -193,8 +193,21 @@ typedef int (*quicrq_object_stream_consumer_fn)(
 
 typedef struct st_quicrq_object_stream_consumer_ctx quicrq_object_stream_consumer_ctx;
 
+typedef enum {
+    quicrq_subscribe_intent_current_group = 0,
+    quicrq_subscribe_intent_current_object = 1,
+    quicrq_subscribe_intent_start_point = 2
+} quicrq_subscribe_intent_enum;
+
+typedef struct st_quicrq_subscribe_intent_t {
+    quicrq_subscribe_intent_enum intent_mode;
+    uint64_t start_group_id;
+    uint64_t start_object_id;
+} quicrq_subscribe_intent_t;
+
 quicrq_object_stream_consumer_ctx* quicrq_subscribe_object_stream(quicrq_cnx_ctx_t* cnx_ctx,
     const uint8_t* url, size_t url_length, int use_datagrams, int in_order_required,
+    quicrq_subscribe_intent_t * intent,
     quicrq_object_stream_consumer_fn media_object_consumer_fn, void* media_object_ctx);
 
 void quicrq_unsubscribe_object_stream(quicrq_object_stream_consumer_ctx* subscribe_ctx);

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -49,6 +49,23 @@ quicrq_ctx_t* quicrq_create(char const* alpn,
 void quicrq_delete(quicrq_ctx_t* ctx);
 picoquic_quic_t* quicrq_get_quic_ctx(quicrq_ctx_t* ctx);
 void quicrq_init_transport_parameters(picoquic_tp_t* tp, int client_mode);
+
+/* Cache management.
+ * Media caches are kept in relays as long as a connection uses them, or up to
+ * 'cache_duration_max' if not in use. This value is set using `quicrq_set_cache_duration`. 
+ * If the value is set to zero, the cache will not be purged.
+ * 
+ * The cache will also not be purged for 30 seconds if it was not filled yet. This happens when 
+ * an empty cache entry is created in response to a media request, but the media
+ * source is not connected yet. This mechanism may have to be revised in a future
+ * version.
+ * 
+ * Cache is purged when `quicrq_time_check` is called, and no purge has been
+ * done for half the maximum duration.
+ */
+#define QUICRQ_CACHE_DURATION_DEFAULT 10000000
+#define QUICRQ_CACHE_INITIAL_DURATION 30000000
+
 void quicrq_set_cache_duration(quicrq_ctx_t* qr_ctx, uint64_t cache_duration_max);
 uint64_t quicrq_time_check(quicrq_ctx_t* qr_ctx, uint64_t current_time);
 

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -195,7 +195,7 @@ typedef struct st_quicrq_object_stream_consumer_ctx quicrq_object_stream_consume
 
 typedef enum {
     quicrq_subscribe_intent_current_group = 0,
-    quicrq_subscribe_intent_current_object = 1,
+    quicrq_subscribe_intent_next_group = 1,
     quicrq_subscribe_intent_start_point = 2
 } quicrq_subscribe_intent_enum;
 

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -96,7 +96,7 @@ typedef struct st_quicrq_media_object_header_t {
  */
 
 typedef struct st_quicrq_media_object_source_properties_t {
-    int use_real_time_caching : 1;
+    unsigned int use_real_time_caching : 1;
     int tbd;
 } quicrq_media_object_source_properties_t;
 
@@ -156,6 +156,7 @@ typedef enum {
     quicrq_media_datagram_ready = 0,
     quicrq_media_start_point,
     quicrq_media_final_object_id,
+    quicrq_media_real_time_cache,
     quicrq_media_close
 } quicrq_media_consumer_enum;
 

--- a/include/quicrq_reassembly.h
+++ b/include/quicrq_reassembly.h
@@ -60,7 +60,8 @@ int quicrq_reassembly_input(
     quicrq_reassembly_object_ready_fn ready_fn,
     void * app_media_ctx);
 
-int quicrq_reassembly_learn_start_point(quicrq_reassembly_context_t* reassembly_ctx, uint64_t start_object_id, uint64_t current_time,
+int quicrq_reassembly_learn_start_point(quicrq_reassembly_context_t* reassembly_ctx,
+    uint64_t start_group_id, uint64_t start_object_id, uint64_t current_time,
     quicrq_reassembly_object_ready_fn ready_fn, void* app_media_ctx);
 
 /* Obtain the final object ID */

--- a/lib/fragment.c
+++ b/lib/fragment.c
@@ -378,13 +378,39 @@ int quicrq_fragment_cache_set_real_time_cache(quicrq_fragment_cached_media_t* ca
     return ret;
 }
 
-/* Purging the old fragments from the cache.
- * There are two modes of operation.
- * In the general case, we want to make sure that all data has a chance of being
- * sent to the clients reading data from the cache. That means:
- *  - only delete objects if all previous objects have been already received,
- *  - only delete objects if all fragments have been received,
- *  - only delete objects if all fragments are old enough.
+/* Purging old fragments from the cache. 
+ * This should only be done for caches of type "real time".
+ * - Compute the latest GOB.
+ *   - lowest of current read point for any reader and last GOB in cache.
+ * - Delete all objects with GOB < last.
+ */
+void quicrq_fragment_cache_media_purge_to_gob(
+    quicrq_fragment_cached_media_t* cached_ctx,
+    uint64_t kept_group_id)
+{
+    picosplay_node_t* fragment_node;
+
+    /* Purge all segments below that GOB. */
+    while ((fragment_node = picosplay_first(&cached_ctx->fragment_tree)) != NULL) {
+        /* Locate the first fragment in object order */
+        quicrq_cached_fragment_t* fragment =
+            (quicrq_cached_fragment_t*)quicrq_fragment_cache_node_value(fragment_node);
+        if (fragment->group_id >= kept_group_id) {
+            /* keep this fragment */
+            cached_ctx->first_group_id = fragment->group_id;
+            cached_ctx->first_object_id = fragment->object_id;
+            break;
+        }
+        else {
+            picosplay_delete_hint(&cached_ctx->fragment_tree, fragment_node);
+        }
+    }
+}
+
+/* Cache management.
+ *
+ * The cache is deleted if nobody is reading it, the final segment is stored,
+ * and enough time has passed -- typically 30 seconds.
  * If the connection feeding the cache is closed, we will not get any new fragment,
  * so there is no point waiting for them to arrive.
  * 

--- a/lib/object_consumer.c
+++ b/lib/object_consumer.c
@@ -94,7 +94,7 @@ int quicrq_media_object_bridge_fn(
         /* Nothing to do there. */
         break;
     case quicrq_media_start_point:
-        ret = quicrq_reassembly_learn_start_point(&bridge_ctx->reassembly_ctx, object_id, current_time,
+        ret = quicrq_reassembly_learn_start_point(&bridge_ctx->reassembly_ctx, group_id, object_id, current_time,
             quicrq_media_object_bridge_ready, bridge_ctx);
         if (ret == 0 && bridge_ctx->reassembly_ctx.is_finished) {
             ret = quicrq_consumer_finished;

--- a/lib/object_consumer.c
+++ b/lib/object_consumer.c
@@ -119,6 +119,7 @@ int quicrq_media_object_bridge_fn(
 /* Subscribe object stream. */
 quicrq_object_stream_consumer_ctx* quicrq_subscribe_object_stream(quicrq_cnx_ctx_t* cnx_ctx,
     const uint8_t* url, size_t url_length, int use_datagrams, int in_order_required,
+    quicrq_subscribe_intent_t * intent,
     quicrq_object_stream_consumer_fn object_stream_consumer_fn, void* object_stream_consumer_ctx)
 {
     quicrq_object_stream_consumer_ctx* bridge_ctx = (quicrq_object_stream_consumer_ctx*)malloc(sizeof(quicrq_object_stream_consumer_ctx));
@@ -132,7 +133,7 @@ quicrq_object_stream_consumer_ctx* quicrq_subscribe_object_stream(quicrq_cnx_ctx
         bridge_ctx->in_order_required = in_order_required;
         quicrq_reassembly_init(&bridge_ctx->reassembly_ctx);
         /* Create a media context for the stream */
-        ret = quicrq_cnx_subscribe_media_ex(cnx_ctx, url, url_length, use_datagrams,
+        ret = quicrq_cnx_subscribe_media_ex(cnx_ctx, url, url_length, use_datagrams, intent,
             quicrq_media_object_bridge_fn, bridge_ctx, &bridge_ctx->stream_ctx);
         if (ret != 0) {
             free(bridge_ctx);

--- a/lib/object_consumer.c
+++ b/lib/object_consumer.c
@@ -90,6 +90,9 @@ int quicrq_media_object_bridge_fn(
             ret = quicrq_consumer_finished;
         }
         break;
+    case quicrq_media_real_time_cache:
+        /* Nothing to do there. */
+        break;
     case quicrq_media_start_point:
         ret = quicrq_reassembly_learn_start_point(&bridge_ctx->reassembly_ctx, object_id, current_time,
             quicrq_media_object_bridge_ready, bridge_ctx);

--- a/lib/object_source.c
+++ b/lib/object_source.c
@@ -43,7 +43,7 @@ quicrq_media_object_source_ctx_t* quicrq_publish_object_source(quicrq_ctx_t* qr_
         */
         object_source_ctx->cached_ctx = quicrq_fragment_cache_create_ctx(qr_ctx);
         if (object_source_ctx->cached_ctx != NULL) {
-            ret = quicrq_publish_fragment_cached_media(qr_ctx, object_source_ctx->cached_ctx, url, url_length, 1);
+            ret = quicrq_publish_fragment_cached_media(qr_ctx, object_source_ctx->cached_ctx, url, url_length, 1, object_source_ctx->properties.use_real_time_caching);
         }
         /* If the API fails, close the media object source */
         if (object_source_ctx->cached_ctx == NULL || ret != 0) {

--- a/lib/proto.c
+++ b/lib/proto.c
@@ -919,7 +919,6 @@ int quicrq_cnx_subscribe_media_ex(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url,
             } else {
                 char buffer[256];
                 /* Queue the media request message to that stream */
-                stream_ctx->is_client = 1;
                 stream_ctx->is_datagram = (use_datagrams != 0);
                 stream_ctx->datagram_stream_id = datagram_stream_id;
                 message->message_size = message_next - message->buffer;
@@ -1002,8 +1001,7 @@ int quicrq_cnx_post_media(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t 
                     ret = -1;
                 }
                 else {
-                    /* Queue the post messageto that stream */
-                    stream_ctx->is_client = 0;
+                    /* Queue the post message to that stream */
                     stream_ctx->is_sender = 1;
                     stream_ctx->is_cache_policy_sent = stream_ctx->is_cache_real_time;
                     message->message_size = message_next - message->buffer;
@@ -1055,7 +1053,6 @@ int quicrq_cnx_accept_media(quicrq_stream_ctx_t * stream_ctx, const uint8_t* url
         else {
             /* Queue the accept message to that stream */
             char buffer[256];
-            stream_ctx->is_client = 1;
             stream_ctx->is_datagram = use_datagrams;
             message->message_size = message_next - message->buffer;
             stream_ctx->send_state = quicrq_sending_initial;

--- a/lib/proto.c
+++ b/lib/proto.c
@@ -895,7 +895,7 @@ int quicrq_cnx_subscribe_media_ex(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url,
     uint64_t stream_id = picoquic_get_next_local_stream_id(cnx_ctx->cnx, 0);
     quicrq_stream_ctx_t* stream_ctx = quicrq_create_stream_context(cnx_ctx, stream_id);
     quicrq_message_buffer_t* message = &stream_ctx->message_sent;
-    static const quicrq_subscribe_intent_t default_intent = { 0 };
+    static const quicrq_subscribe_intent_t default_intent = { quicrq_subscribe_intent_start_point, 0, 0 };
 
     if (intent == NULL) {
         intent = &default_intent;

--- a/lib/proto.c
+++ b/lib/proto.c
@@ -357,6 +357,33 @@ const uint8_t* quicrq_start_point_msg_decode(const uint8_t* bytes, const uint8_t
     return bytes;
 }
 
+/* Cache Policy Message
+ *     message_type(i),
+ *     cache_policy(i)
+ */
+size_t quicrq_cache_policy_msg_reserve()
+{
+    size_t len = 2;
+    return len;
+}
+
+
+uint8_t* quicrq_cache_policy_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, uint8_t cache_policy)
+{
+    if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, message_type)) != NULL) {
+        bytes = picoquic_frames_uint8_encode(bytes, bytes_max, cache_policy);
+    }
+    return bytes;
+}
+
+const uint8_t* quicrq_cache_policy_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, uint8_t* cache_policy)
+{
+    if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, message_type)) != NULL){
+        bytes = picoquic_frames_uint8_decode(bytes, bytes_max, cache_policy);
+    }
+    return bytes;
+}
+
 /* Media POST message.  
  *     message_type(i),
  *     url_length(i),
@@ -493,6 +520,9 @@ const uint8_t* quicrq_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max,
         case QUICRQ_ACTION_NOTIFY:
             bytes = quicrq_notify_msg_decode(bytes, bytes_max, &msg->message_type, &msg->url_length, &msg->url);
             break;
+        case QUICRQ_ACTION_CACHE_POLICY:
+            bytes = quicrq_cache_policy_msg_decode(bytes, bytes_max, &msg->message_type, &msg->cache_policy);
+            break;
         default:
             /* Unexpected message type */
             bytes = NULL;
@@ -535,6 +565,9 @@ uint8_t* quicrq_msg_encode(uint8_t* bytes, uint8_t* bytes_max, quicrq_message_t*
         break;
     case QUICRQ_ACTION_NOTIFY:
         bytes = quicrq_notify_msg_encode(bytes, bytes_max, msg->message_type, msg->url_length, msg->url);
+        break;
+    case QUICRQ_ACTION_CACHE_POLICY:
+        bytes = quicrq_cache_policy_msg_encode(bytes, bytes_max, msg->message_type, msg->cache_policy);
         break;
     default:
         /* Unexpected message type */

--- a/lib/proto.c
+++ b/lib/proto.c
@@ -642,7 +642,7 @@ const uint8_t* quicrq_datagram_header_decode(const uint8_t* bytes, const uint8_t
  */
 
 quicrq_media_source_ctx_t* quicrq_publish_datagram_source(quicrq_ctx_t* qr_ctx, const uint8_t* url, size_t url_length,
-    void* pub_ctx, int is_local_object_source)
+    void* pub_ctx, int is_local_object_source, int is_cache_real_time)
 {
     quicrq_media_source_ctx_t* srce_ctx = NULL;
     size_t source_ctx_size = sizeof(quicrq_media_source_ctx_t) + url_length;
@@ -655,6 +655,7 @@ quicrq_media_source_ctx_t* quicrq_publish_datagram_source(quicrq_ctx_t* qr_ctx, 
             srce_ctx->media_url = ((uint8_t*)srce_ctx) + sizeof(quicrq_media_source_ctx_t);
             srce_ctx->media_url_length = url_length;
             memcpy(srce_ctx->media_url, url, url_length);
+            srce_ctx->is_cache_real_time = is_cache_real_time;
             if (qr_ctx->last_source == NULL) {
                 qr_ctx->first_source = srce_ctx;
                 qr_ctx->last_source = srce_ctx;

--- a/lib/quicrq.c
+++ b/lib/quicrq.c
@@ -1224,6 +1224,28 @@ int quicrq_prepare_to_send_on_stream(quicrq_stream_ctx_t* stream_ctx, void* cont
                     }
                 }
             }
+#if 0
+            else if (stream_ctx->is_cache_real_time && !stream_ctx->is_cache_policy_sent) {
+                quicrq_log_message(stream_ctx->cnx_ctx,
+                    "Stream %" PRIu64 ", sending start object id: %" PRIu64 "/%" PRIu64,
+                    stream_ctx->stream_id, stream_ctx->start_group_id, stream_ctx->start_object_id);
+                if (quicrq_msg_buffer_alloc(message, quicrq_start_point_msg_reserve(stream_ctx->start_group_id, stream_ctx->start_object_id), 0) != 0) {
+                    ret = -1;
+                }
+                else {
+                    uint8_t* message_next = quicrq_start_point_msg_encode(message->buffer, message->buffer + message->buffer_alloc, QUICRQ_ACTION_START_POINT,
+                        stream_ctx->start_group_id, stream_ctx->start_object_id);
+                    if (message_next == NULL) {
+                        ret = -1;
+                    }
+                    else {
+                        /* Queue the media request message to that stream */
+                        message->message_size = message_next - message->buffer;
+                        stream_ctx->send_state = quicrq_sending_start_point;
+                    }
+                }
+            }
+#endif
             else {
                 /* This is a bug. If there is nothing to send, we should not be sending any stream data */
                 quicrq_log_message(stream_ctx->cnx_ctx, "Nothing to send on stream %" PRIu64 ", state: %d, final: %" PRIu64,

--- a/lib/quicrq.c
+++ b/lib/quicrq.c
@@ -1575,13 +1575,15 @@ int quicrq_receive_stream_data(quicrq_stream_ctx_t* stream_ctx, uint8_t* bytes, 
                                     }
                                 }
                             }
-                            if (intent_group > 0 || intent_object > 0){
+                            if (intent_group > 0 || intent_object > 0) {
                                 /* apply the intent, prepare a start point message */
                                 stream_ctx->start_group_id = intent_group;
                                 stream_ctx->start_object_id = intent_object;
                                 stream_ctx->next_group_id = intent_group;
                                 stream_ctx->next_object_id = intent_object;
-
+                                stream_ctx->media_ctx->current_group_id = intent_group;
+                                stream_ctx->media_ctx->current_object_id = intent_object;
+                                stream_ctx->media_ctx->current_offset = 0;
                                 ret = quicrq_prepare_start_point(stream_ctx);
                                 stream_ctx->receive_state = quicrq_receive_done;
                                 picoquic_mark_active_stream(stream_ctx->cnx_ctx->cnx, stream_ctx->stream_id, 1, stream_ctx);

--- a/lib/quicrq.c
+++ b/lib/quicrq.c
@@ -512,11 +512,6 @@ int quicrq_receive_datagram(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* bytes, siz
                 picoquic_log_app_message(cnx_ctx->cnx, "Received final fragment of object %" PRIu64 " on datagram stream %" PRIu64 ", stream %" PRIu64,
                     object_id, datagram_stream_id, stream_ctx->stream_id);
             }
-#if 1
-            if (cnx_ctx->qr_ctx->relay_ctx == NULL) {
-                DBG_PRINTF("%s", "bug");
-            }
-#endif
             ret = stream_ctx->consumer_fn(quicrq_media_datagram_ready, stream_ctx->media_ctx, current_time, next_bytes, group_id, object_id, object_offset, 
                 queue_delay, flags, nb_objects_previous_group, is_last_fragment, bytes_max - next_bytes);
             if (ret == quicrq_consumer_finished) {
@@ -1137,11 +1132,6 @@ int quicrq_prepare_to_send_datagram(quicrq_cnx_ctx_t* cnx_ctx, void* context, si
      */
 
     while (stream_ctx != NULL) {
-#if 1
-        if (cnx_ctx->qr_ctx->relay_ctx != NULL) {
-            DBG_PRINTF("%s", "Bug");
-        }
-#endif
         if (stream_ctx->is_datagram && stream_ctx->is_sender && stream_ctx->is_active_datagram && stream_ctx->datagram_stream_id < UINT64_MAX) {
             int media_was_sent = 0;
             ret = quicrq_fragment_datagram_publisher_fn(stream_ctx, context, space, &media_was_sent, &at_least_one_active, current_time);
@@ -1875,7 +1865,6 @@ quicrq_stream_ctx_t* quicrq_cnx_subscribe_pattern(quicrq_cnx_ctx_t* cnx_ctx, con
                 stream_ctx->media_notify_fn = media_notify_fn;
                 stream_ctx->notify_ctx = notify_ctx;
                 /* Queue the media request message to that stream */
-                stream_ctx->is_client = 1;
                 message->message_size = message_next - message->buffer;
                 stream_ctx->send_state = quicrq_sending_subscribe;
                 stream_ctx->receive_state = quicrq_receive_notify;

--- a/lib/quicrq.c
+++ b/lib/quicrq.c
@@ -2018,6 +2018,7 @@ quicrq_ctx_t* quicrq_create(char const* alpn,
         else {
             picoquic_set_default_congestion_algorithm(qr_ctx->quic, picoquic_bbr_algorithm);
             picoquic_set_default_priority(qr_ctx->quic, 4);
+            qr_ctx->cache_duration_max = QUICRQ_CACHE_DURATION_DEFAULT;
         }
     }
     return qr_ctx;

--- a/lib/quicrq_fragment.h
+++ b/lib/quicrq_fragment.h
@@ -47,6 +47,7 @@ typedef struct st_quicrq_fragment_cached_media_t {
     quicrq_cached_fragment_t* last_fragment;
     picosplay_tree_t fragment_tree;
     int is_closed;
+    int use_real_time_caching : 1;
     uint64_t cache_delete_time;
 } quicrq_fragment_cached_media_t;
 
@@ -121,6 +122,8 @@ int quicrq_fragment_cache_learn_start_point(quicrq_fragment_cached_media_t* cach
     uint64_t start_group_id, uint64_t start_object_id);
 
 int quicrq_fragment_cache_learn_end_point(quicrq_fragment_cached_media_t* cached_ctx, uint64_t final_group_id, uint64_t final_object_id);
+
+int quicrq_fragment_cache_set_real_time_cache(quicrq_fragment_cached_media_t* cached_ctx);
 
 /* Purging the old fragments from the cache.
  * There are two modes of operation.

--- a/lib/quicrq_fragment.h
+++ b/lib/quicrq_fragment.h
@@ -125,6 +125,16 @@ int quicrq_fragment_cache_learn_end_point(quicrq_fragment_cached_media_t* cached
 
 int quicrq_fragment_cache_set_real_time_cache(quicrq_fragment_cached_media_t* cached_ctx);
 
+/* Purging old fragments from the cache. 
+ * This should only be done for caches of type "real time".
+ * - Compute the first kept GOB.
+ *   - lowest of current read point for any reader and last GOB in cache.
+ * - Delete all objects with GOB < first kept.
+ */
+void quicrq_fragment_cache_media_purge_to_gob(
+    quicrq_fragment_cached_media_t* cached_ctx,
+    uint64_t kept_group_id);
+
 /* Purging the old fragments from the cache.
  * There are two modes of operation.
  * In the general case, we want to make sure that all data has a chance of being

--- a/lib/quicrq_fragment.h
+++ b/lib/quicrq_fragment.h
@@ -47,7 +47,6 @@ typedef struct st_quicrq_fragment_cached_media_t {
     quicrq_cached_fragment_t* last_fragment;
     picosplay_tree_t fragment_tree;
     int is_closed;
-    int use_real_time_caching : 1;
     uint64_t cache_delete_time;
 } quicrq_fragment_cached_media_t;
 
@@ -132,8 +131,7 @@ int quicrq_fragment_cache_set_real_time_cache(quicrq_fragment_cached_media_t* ca
  * - Delete all objects with GOB < first kept.
  */
 void quicrq_fragment_cache_media_purge_to_gob(
-    quicrq_fragment_cached_media_t* cached_ctx,
-    uint64_t kept_group_id);
+    quicrq_media_source_ctx_t* srce_ctx);
 
 /* Purging the old fragments from the cache.
  * There are two modes of operation.
@@ -281,7 +279,7 @@ void quicrq_fragment_publisher_delete(void* v_pub_ctx);
 /* Fragment cache media publish */
 int quicrq_publish_fragment_cached_media(quicrq_ctx_t* qr_ctx,
     quicrq_fragment_cached_media_t* cache_ctx, const uint8_t* url, const size_t url_length,
-    int is_local_object_source);
+    int is_local_object_source, int is_cache_real_time);
 
 #ifdef __cplusplus
 }

--- a/lib/quicrq_fragment.h
+++ b/lib/quicrq_fragment.h
@@ -31,24 +31,24 @@ typedef struct st_quicrq_cached_fragment_t {
     uint8_t* data;
 } quicrq_cached_fragment_t;
 
-typedef struct st_quicrq_fragment_cached_media_t {
-    quicrq_media_source_ctx_t* srce_ctx;
-    quicrq_ctx_t* qr_ctx;
-    uint64_t final_group_id;
-    uint64_t final_object_id;
-    uint64_t nb_object_received;
-    uint64_t subscribe_stream_id;
-    uint64_t first_group_id;
-    uint64_t first_object_id;
-    uint64_t next_group_id;
-    uint64_t next_object_id;
-    uint64_t next_offset;
-    quicrq_cached_fragment_t* first_fragment;
+typedef struct st_quicrq_fragment_cache_t {
+    quicrq_media_source_ctx_t* srce_ctx; /* Back pointer to source context */
+    quicrq_ctx_t* qr_ctx; /* back pointer to quicrq context */
+    uint64_t final_group_id; /* 0 if unknown, value if known */
+    uint64_t final_object_id; /* 0 if unknown, value if known */
+    uint64_t nb_object_received; /* For statistics only */
+    uint64_t subscribe_stream_id; /* ID of stream in connection to origin, or UINT64_MAX */
+    uint64_t first_group_id; /* First group in cache, start at 0, modifies if start point learned or after objects removed from cache */
+    uint64_t first_object_id; /* First object in first group, see first_group_id */
+    uint64_t next_group_id; /* Updated as objects are added sequentially to cache */
+    uint64_t next_object_id; /* Updated as objects are added sequentially to cache */
+    uint64_t next_offset; /* Updated as objects are added sequentially to cache */
+    quicrq_cached_fragment_t* first_fragment; /* Fragments in order of arrival */
     quicrq_cached_fragment_t* last_fragment;
-    picosplay_tree_t fragment_tree;
-    int is_closed;
+    picosplay_tree_t fragment_tree; /* Splay ordered by group_id/object_id/offset */
+    int is_feed_closed; /* Whether the data providing connection is closed. */
     uint64_t cache_delete_time;
-} quicrq_fragment_cached_media_t;
+} quicrq_fragment_cache_t;
 
 typedef struct st_quicrq_fragment_publisher_object_state_t {
     picosplay_node_t publisher_object_node;
@@ -62,7 +62,7 @@ typedef struct st_quicrq_fragment_publisher_object_state_t {
 } quicrq_fragment_publisher_object_state_t;
 
 typedef struct st_quicrq_fragment_publisher_context_t {
-    quicrq_fragment_cached_media_t* cache_ctx;
+    quicrq_fragment_cache_t* cache_ctx;
     uint64_t current_group_id;
     uint64_t current_object_id;
     size_t current_offset;
@@ -80,20 +80,20 @@ typedef struct st_quicrq_fragment_publisher_context_t {
 
 void* quicrq_fragment_cache_node_value(picosplay_node_t* fragment_node);
 
-quicrq_cached_fragment_t* quicrq_fragment_cache_get_fragment(quicrq_fragment_cached_media_t* cached_ctx,
+quicrq_cached_fragment_t* quicrq_fragment_cache_get_fragment(quicrq_fragment_cache_t* cached_ctx,
     uint64_t group_id, uint64_t object_id, uint64_t offset);
 
-void quicrq_fragment_cache_media_clear(quicrq_fragment_cached_media_t* cached_media);
+void quicrq_fragment_cache_media_clear(quicrq_fragment_cache_t* cached_media);
 
-void quicrq_fragment_cache_media_init(quicrq_fragment_cached_media_t* cached_media);
+void quicrq_fragment_cache_media_init(quicrq_fragment_cache_t* cached_media);
 
 /* Fragment cache progress.
  * Manage the "next_group" and "next_object" items.
  */
-void quicrq_fragment_cache_progress(quicrq_fragment_cached_media_t* cached_ctx,
+void quicrq_fragment_cache_progress(quicrq_fragment_cache_t* cached_ctx,
     quicrq_cached_fragment_t* fragment);
 
-int quicrq_fragment_add_to_cache(quicrq_fragment_cached_media_t* cached_ctx,
+int quicrq_fragment_add_to_cache(quicrq_fragment_cache_t* cached_ctx,
     const uint8_t* data,
     uint64_t group_id,
     uint64_t object_id,
@@ -105,7 +105,7 @@ int quicrq_fragment_add_to_cache(quicrq_fragment_cached_media_t* cached_ctx,
     size_t data_length,
     uint64_t current_time);
 
-int quicrq_fragment_propose_to_cache(quicrq_fragment_cached_media_t* cached_ctx,
+int quicrq_fragment_propose_to_cache(quicrq_fragment_cache_t* cached_ctx,
     const uint8_t* data,
     uint64_t group_id,
     uint64_t object_id,
@@ -117,12 +117,12 @@ int quicrq_fragment_propose_to_cache(quicrq_fragment_cached_media_t* cached_ctx,
     size_t data_length,
     uint64_t current_time);
 
-int quicrq_fragment_cache_learn_start_point(quicrq_fragment_cached_media_t* cached_ctx,
+int quicrq_fragment_cache_learn_start_point(quicrq_fragment_cache_t* cached_ctx,
     uint64_t start_group_id, uint64_t start_object_id);
 
-int quicrq_fragment_cache_learn_end_point(quicrq_fragment_cached_media_t* cached_ctx, uint64_t final_group_id, uint64_t final_object_id);
+int quicrq_fragment_cache_learn_end_point(quicrq_fragment_cache_t* cached_ctx, uint64_t final_group_id, uint64_t final_object_id);
 
-int quicrq_fragment_cache_set_real_time_cache(quicrq_fragment_cached_media_t* cached_ctx);
+int quicrq_fragment_cache_set_real_time_cache(quicrq_fragment_cache_t* cached_ctx);
 
 /* Purging old fragments from the cache. 
  * This should only be done for caches of type "real time".
@@ -149,14 +149,14 @@ void quicrq_fragment_cache_media_purge_to_gob(
  */
 
 void quicrq_fragment_cache_media_purge(
-    quicrq_fragment_cached_media_t* cached_media,
+    quicrq_fragment_cache_t* cached_media,
     uint64_t current_time,
     uint64_t cache_duration_max,
     uint64_t first_object_id_kept);
 
-void quicrq_fragment_cache_delete_ctx(quicrq_fragment_cached_media_t* cache_ctx);
+void quicrq_fragment_cache_delete_ctx(quicrq_fragment_cache_t* cache_ctx);
 
-quicrq_fragment_cached_media_t* quicrq_fragment_cache_create_ctx(quicrq_ctx_t* qr_ctx);
+quicrq_fragment_cache_t* quicrq_fragment_cache_create_ctx(quicrq_ctx_t* qr_ctx);
 
 /* Fragment publisher
  * 
@@ -196,6 +196,8 @@ int quicrq_fragment_publisher_fn(
     int* is_still_active,
     int* has_backlog,
     uint64_t current_time);
+
+int quicrq_fragment_is_ready_to_send(void* v_media_ctx, size_t data_max_size, uint64_t current_time);
 
 
 /* Evaluate whether the media context has backlog, and check
@@ -272,13 +274,13 @@ int quicrq_fragment_datagram_publisher_fn(
     int* at_least_one_active,
     uint64_t current_time);
 
-void* quicrq_fragment_publisher_subscribe(void* v_srce_ctx, quicrq_stream_ctx_t* stream_ctx);
+void* quicrq_fragment_publisher_subscribe(quicrq_fragment_cache_t* cache_ctx, quicrq_stream_ctx_t* stream_ctx);
 
 void quicrq_fragment_publisher_delete(void* v_pub_ctx);
 
 /* Fragment cache media publish */
 int quicrq_publish_fragment_cached_media(quicrq_ctx_t* qr_ctx,
-    quicrq_fragment_cached_media_t* cache_ctx, const uint8_t* url, const size_t url_length,
+    quicrq_fragment_cache_t* cache_ctx, const uint8_t* url, const size_t url_length,
     int is_local_object_source, int is_cache_real_time);
 
 #ifdef __cplusplus

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -315,7 +315,7 @@ typedef enum {
     quicrq_sending_stream,
     quicrq_sending_initial,
     quicrq_sending_repair,
-    quicrq_sending_offset,
+    quicrq_sending_final_point,
     quicrq_sending_start_point,
     quicrq_sending_cache_policy,
     quicrq_sending_fin,

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -93,6 +93,7 @@ typedef struct st_quicrq_message_t {
     const uint8_t* data;
     unsigned int use_datagram;
     uint8_t cache_policy;
+    quicrq_subscribe_intent_enum subscribe_intent;
 } quicrq_message_t;
 
 /* Encode and decode protocol messages
@@ -119,9 +120,11 @@ const uint8_t* quicrq_subscribe_msg_decode(const uint8_t* bytes, const uint8_t* 
 size_t quicrq_notify_msg_reserve(size_t url_length);
 uint8_t* quicrq_notify_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length, const uint8_t* url);
 const uint8_t* quicrq_notify_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, size_t* url_length, const uint8_t** url);
-size_t quicrq_rq_msg_reserve(size_t url_length);
-uint8_t* quicrq_rq_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length, const uint8_t* url, uint64_t datagram_stream_id);
-const uint8_t* quicrq_rq_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, size_t* url_length, const uint8_t** url, uint64_t* datagram_stream_id);
+size_t quicrq_rq_msg_reserve(size_t url_length, quicrq_subscribe_intent_enum intent_mode);
+uint8_t* quicrq_rq_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length, const uint8_t* url,
+    quicrq_subscribe_intent_enum intent_mode, uint64_t start_group_id,  uint64_t start_object_id, uint64_t datagram_stream_id);
+const uint8_t* quicrq_rq_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, size_t* url_length, const uint8_t** url,
+    quicrq_subscribe_intent_enum * intent_mode, uint64_t * start_group_id,  uint64_t * start_object_id, uint64_t* datagram_stream_id);
 size_t quicrq_post_msg_reserve(size_t url_length);
 uint8_t* quicrq_post_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length, const uint8_t* url, unsigned int datagram_capable, uint8_t cache_policy);
 const uint8_t* quicrq_post_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, size_t* url_length, const uint8_t** url, unsigned int* datagram_capable, uint8_t* cache_policy);
@@ -295,7 +298,8 @@ int quicrq_cnx_subscribe_media(quicrq_cnx_ctx_t* cnx_ctx,
     quicrq_media_consumer_fn media_consumer_fn, void* media_ctx);
 
 int quicrq_cnx_subscribe_media_ex(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length,
-    int use_datagrams, quicrq_media_consumer_fn media_consumer_fn, void* media_ctx, quicrq_stream_ctx_t** p_stream_ctx);
+    int use_datagrams, const quicrq_subscribe_intent_t * intent,
+    quicrq_media_consumer_fn media_consumer_fn, void* media_ctx, quicrq_stream_ctx_t** p_stream_ctx);
 
 
 /* Quicrq stream handling.

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -228,7 +228,7 @@ void quicrq_delete_source(quicrq_media_source_ctx_t* srce_ctx, quicrq_ctx_t* qr_
 void quicrq_source_wakeup(quicrq_media_source_ctx_t* srce_ctx);
 
 quicrq_media_source_ctx_t* quicrq_publish_datagram_source(quicrq_ctx_t* qr_ctx, const uint8_t* url, size_t url_length,
-    void* pub_ctx, int is_local_object_source, int is_cache_real_time);
+    void* cache_ctx, int is_local_object_source, int is_cache_real_time);
 
  /* Quicrq per media object source context.
   */
@@ -238,7 +238,7 @@ struct st_quicrq_media_object_source_ctx_t {
     struct st_quicrq_media_object_source_ctx_t* previous_in_qr_ctx;
     struct st_quicrq_media_object_source_ctx_t* next_in_qr_ctx;
 
-    struct st_quicrq_fragment_cached_media_t* cached_ctx;
+    struct st_quicrq_fragment_cache_t* cache_ctx;
     uint64_t next_group_id;
     uint64_t next_object_id;
     quicrq_media_object_source_properties_t properties;
@@ -255,10 +255,7 @@ struct st_quicrq_media_source_ctx_t {
     struct st_quicrq_stream_ctx_t* last_stream;
     uint8_t* media_url;
     size_t media_url_length;
-
-    struct st_quicrq_fragment_cached_media_t* fragment_cache;
-
-    void* pub_ctx;
+    struct st_quicrq_fragment_cache_t* cache_ctx;
     int is_local_object_source;
     int is_cache_real_time;
 };
@@ -443,7 +440,7 @@ struct st_quicrq_stream_ctx_t {
     quicrq_message_buffer_t message_receive;
 
     quicrq_media_consumer_fn consumer_fn; /* Callback function for media data arrival  */
-    void* media_ctx; /* Callback argument for receiving or sending data */
+    struct st_quicrq_fragment_publisher_context_t* media_ctx; /* Callback argument for receiving or sending data */
 };
 
 int quicrq_set_media_stream_ctx(quicrq_stream_ctx_t* stream_ctx, quicrq_media_consumer_fn media_fn, void* media_ctx);
@@ -467,6 +464,7 @@ struct st_quicrq_cnx_ctx_t {
     struct sockaddr_storage addr;
     picoquic_cnx_t* cnx;
     int is_server;
+    int is_client;
     quicrq_cnx_congestion_state_t congestion;
 
     uint64_t next_datagram_stream_id; /* only used for receiving */

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -411,7 +411,6 @@ struct st_quicrq_stream_ctx_t {
     /* Stream state */
     quicrq_stream_sending_state_enum send_state;
     quicrq_stream_receive_state_enum receive_state;
-    unsigned int is_client : 1;
     unsigned int is_sender : 1;
     /* Indicates whether local cache management follows the "real time" logic,
      * in which only recent objects are kept. By default, cache management 
@@ -432,9 +431,6 @@ struct st_quicrq_stream_ctx_t {
     unsigned int is_start_object_id_sent : 1;
     unsigned int is_final_object_id_sent : 1;
     unsigned int is_cache_policy_sent : 1;
-
-    size_t bytes_sent;
-    size_t bytes_received;
 
     quicrq_message_buffer_t message_sent;
     quicrq_message_buffer_t message_receive;

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -225,7 +225,7 @@ void quicrq_delete_source(quicrq_media_source_ctx_t* srce_ctx, quicrq_ctx_t* qr_
 void quicrq_source_wakeup(quicrq_media_source_ctx_t* srce_ctx);
 
 quicrq_media_source_ctx_t* quicrq_publish_datagram_source(quicrq_ctx_t* qr_ctx, const uint8_t* url, size_t url_length,
-    void* pub_ctx, int is_local_object_source);
+    void* pub_ctx, int is_local_object_source, int is_cache_real_time);
 
  /* Quicrq per media object source context.
   */
@@ -316,6 +316,7 @@ typedef enum {
     quicrq_sending_repair,
     quicrq_sending_offset,
     quicrq_sending_start_point,
+    quicrq_sending_cache_policy,
     quicrq_sending_fin,
     quicrq_sending_subscribe,
     quicrq_waiting_notify,

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -122,6 +122,9 @@ const uint8_t* quicrq_notify_msg_decode(const uint8_t* bytes, const uint8_t* byt
 size_t quicrq_rq_msg_reserve(size_t url_length);
 uint8_t* quicrq_rq_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length, const uint8_t* url, uint64_t datagram_stream_id);
 const uint8_t* quicrq_rq_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, size_t* url_length, const uint8_t** url, uint64_t* datagram_stream_id);
+size_t quicrq_post_msg_reserve(size_t url_length);
+uint8_t* quicrq_post_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length, const uint8_t* url, unsigned int datagram_capable, uint8_t cache_policy);
+const uint8_t* quicrq_post_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, size_t* url_length, const uint8_t** url, unsigned int* datagram_capable, uint8_t* cache_policy);
 size_t quicrq_fin_msg_reserve(uint64_t final_group_id, uint64_t final_object_id);
 uint8_t* quicrq_fin_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, 
     uint64_t final_group_id, uint64_t final_object_id);
@@ -254,6 +257,7 @@ struct st_quicrq_media_source_ctx_t {
 
     void* pub_ctx;
     int is_local_object_source;
+    int is_cache_real_time;
 };
 
 quicrq_media_source_ctx_t* quicrq_find_local_media_source(quicrq_ctx_t* qr_ctx, const uint8_t* url, const size_t url_length);
@@ -366,6 +370,7 @@ struct st_quicrq_stream_ctx_t {
     struct st_quicrq_stream_ctx_t* next_stream;
     struct st_quicrq_stream_ctx_t* previous_stream;
     struct st_quicrq_cnx_ctx_t* cnx_ctx;
+    /* Source from which data is read and sent on the stream. */
     quicrq_media_source_ctx_t* media_source;
     struct st_quicrq_stream_ctx_t* next_stream_for_source;
     struct st_quicrq_stream_ctx_t* previous_stream_for_source;
@@ -540,7 +545,7 @@ uint8_t* quicr_encode_object_header(uint8_t* fh, const uint8_t* fh_max, const qu
 
 /* Process a receive POST command */
 int quicrq_cnx_accept_media(quicrq_stream_ctx_t* stream_ctx, const uint8_t* url, size_t url_length,
-    int use_datagrams);
+    int use_datagrams, uint8_t cache_policy);
 
 /*  Process a received ACCEPT response */
 int quicrq_cnx_post_accepted(quicrq_stream_ctx_t* stream_ctx, unsigned int use_datagrams, uint64_t datagram_stream_id);

--- a/lib/quicrq_relay_internal.h
+++ b/lib/quicrq_relay_internal.h
@@ -49,6 +49,7 @@
   */
 
 typedef struct st_quicrq_relay_consumer_context_t {
+    quicrq_ctx_t* qr_ctx;
     uint64_t last_object_id;
     quicrq_fragment_cached_media_t* cached_ctx;
 } quicrq_relay_consumer_context_t;

--- a/lib/quicrq_relay_internal.h
+++ b/lib/quicrq_relay_internal.h
@@ -50,8 +50,7 @@
 
 typedef struct st_quicrq_relay_consumer_context_t {
     quicrq_ctx_t* qr_ctx;
-    uint64_t last_object_id;
-    quicrq_fragment_cached_media_t* cached_ctx;
+    quicrq_fragment_cache_t* cache_ctx;
 } quicrq_relay_consumer_context_t;
 
 typedef struct st_quicrq_relay_context_t {

--- a/lib/relay.c
+++ b/lib/relay.c
@@ -79,6 +79,10 @@ int quicrq_relay_consumer_cb(
             }
         }
         break;
+    case quicrq_media_real_time_cache:
+        /* Set the cache policy to real time for the media, and then for all subscribed groups */
+        ret = quicrq_fragment_cache_set_real_time_cache(cons_ctx->cached_ctx);
+        break;
     case quicrq_media_start_point:
         /* Document the start point, and clean the cache of data before that point */
         ret = quicrq_fragment_cache_learn_start_point(cons_ctx->cached_ctx, group_id, object_id);
@@ -329,8 +333,6 @@ int quicrq_relay_consumer_init_callback(quicrq_stream_ctx_t* stream_ctx, const u
 
     return ret;
 }
-
-
 
 /* Management of subscriptions on relays.
  *

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -68,6 +68,7 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_datagram_extra", quicrq_triangle_datagram_extra_test },
     { "triangle_start_point", quicrq_triangle_start_point_test },
     { "triangle_cache", quicrq_triangle_cache_test },
+    { "triangle_cache_stream", quicrq_triangle_cache_stream_test },
     { "pyramid_basic", quicrq_pyramid_basic_test },
     { "pyramid_datagram", quicrq_pyramid_datagram_test },
     { "pyramid_datagram_loss", quicrq_pyramid_datagram_loss_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -76,6 +76,7 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_intent", quicrq_triangle_intent_test },
     { "triangle_intent_datagram", quicrq_triangle_intent_datagram_test },
     { "triangle_intent_loss", quicrq_triangle_intent_loss_test },
+    { "triangle_intent_next", quicrq_triangle_intent_next_test },
     { "pyramid_basic", quicrq_pyramid_basic_test },
     { "pyramid_datagram", quicrq_pyramid_datagram_test },
     { "pyramid_datagram_loss", quicrq_pyramid_datagram_loss_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -68,6 +68,7 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_datagram_extra", quicrq_triangle_datagram_extra_test },
     { "triangle_start_point", quicrq_triangle_start_point_test },
     { "triangle_cache", quicrq_triangle_cache_test },
+    { "triangle_cache_loss", quicrq_triangle_cache_loss_test },
     { "triangle_cache_stream", quicrq_triangle_cache_stream_test },
     { "pyramid_basic", quicrq_pyramid_basic_test },
     { "pyramid_datagram", quicrq_pyramid_datagram_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -77,6 +77,7 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_intent_datagram", quicrq_triangle_intent_datagram_test },
     { "triangle_intent_loss", quicrq_triangle_intent_loss_test },
     { "triangle_intent_next", quicrq_triangle_intent_next_test },
+    { "triangle_intent_next_s", quicrq_triangle_intent_next_s_test },
     { "pyramid_basic", quicrq_pyramid_basic_test },
     { "pyramid_datagram", quicrq_pyramid_datagram_test },
     { "pyramid_datagram_loss", quicrq_pyramid_datagram_loss_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -66,7 +66,10 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_datagram", quicrq_triangle_datagram_test },
     { "triangle_datagram_loss", quicrq_triangle_datagram_loss_test },
     { "triangle_datagram_extra", quicrq_triangle_datagram_extra_test },
+#if 0
+    /* Start point function is superceded by "subscribe intent" */
     { "triangle_start_point", quicrq_triangle_start_point_test },
+#endif
     { "triangle_cache", quicrq_triangle_cache_test },
     { "triangle_cache_loss", quicrq_triangle_cache_loss_test },
     { "triangle_cache_stream", quicrq_triangle_cache_stream_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -74,6 +74,7 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_cache_loss", quicrq_triangle_cache_loss_test },
     { "triangle_cache_stream", quicrq_triangle_cache_stream_test },
     { "triangle_intent", quicrq_triangle_intent_test },
+    { "triangle_intent_datagram", quicrq_triangle_intent_datagram_test },
     { "pyramid_basic", quicrq_pyramid_basic_test },
     { "pyramid_datagram", quicrq_pyramid_datagram_test },
     { "pyramid_datagram_loss", quicrq_pyramid_datagram_loss_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -78,6 +78,8 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_intent_loss", quicrq_triangle_intent_loss_test },
     { "triangle_intent_next", quicrq_triangle_intent_next_test },
     { "triangle_intent_next_s", quicrq_triangle_intent_next_s_test },
+    { "triangle_intent_that", quicrq_triangle_intent_that_test },
+    { "triangle_intent_that_s", quicrq_triangle_intent_that_s_test },
     { "pyramid_basic", quicrq_pyramid_basic_test },
     { "pyramid_datagram", quicrq_pyramid_datagram_test },
     { "pyramid_datagram_loss", quicrq_pyramid_datagram_loss_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -75,6 +75,7 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_cache_stream", quicrq_triangle_cache_stream_test },
     { "triangle_intent", quicrq_triangle_intent_test },
     { "triangle_intent_datagram", quicrq_triangle_intent_datagram_test },
+    { "triangle_intent_loss", quicrq_triangle_intent_loss_test },
     { "pyramid_basic", quicrq_pyramid_basic_test },
     { "pyramid_datagram", quicrq_pyramid_datagram_test },
     { "pyramid_datagram_loss", quicrq_pyramid_datagram_loss_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -70,6 +70,7 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_cache", quicrq_triangle_cache_test },
     { "triangle_cache_loss", quicrq_triangle_cache_loss_test },
     { "triangle_cache_stream", quicrq_triangle_cache_stream_test },
+    { "triangle_intent", quicrq_triangle_intent_test },
     { "pyramid_basic", quicrq_pyramid_basic_test },
     { "pyramid_datagram", quicrq_pyramid_datagram_test },
     { "pyramid_datagram_loss", quicrq_pyramid_datagram_loss_test },

--- a/tests/basic_test.c
+++ b/tests/basic_test.c
@@ -178,7 +178,7 @@ int quicrq_test_loop_step(quicrq_test_config_t* config, int* is_active, uint64_t
     int ret = 0;
     int next_step_type = 0;
     int next_step_index = 0;
-    uint64_t next_time = UINT64_MAX;
+    uint64_t next_time = config->next_test_event_time;
 
     /* Check which object source has the lowest time */
     for (int i = 0; i < config->nb_object_sources; i++) {
@@ -223,10 +223,10 @@ int quicrq_test_loop_step(quicrq_test_config_t* config, int* is_active, uint64_t
         if (next_time > config->simulated_time) {
             config->simulated_time = next_time;
         }
-        else {
-            next_time = config->simulated_time;
-        }
+        next_time = config->simulated_time;
         switch (next_step_type) {
+        case 0:
+            break;
         case 1:
             /* Simulate arrival of data for an object source */
             ret = test_media_object_source_iterate(config->object_sources[next_step_index], next_time, is_active);
@@ -345,6 +345,7 @@ quicrq_test_config_t* quicrq_test_config_create(int nb_nodes, int nb_links, int 
 
         memset(config, 0, sizeof(quicrq_test_config_t));
         memset(config->ticket_encryption_key, 0x55, sizeof(config->ticket_encryption_key));
+        config->next_test_event_time = UINT64_MAX;
 
         /* Locate the default cert, key and root in the certs folder */
         if (picoquic_get_input_path(config->test_server_cert_file, sizeof(config->test_server_cert_file),

--- a/tests/basic_test.c
+++ b/tests/basic_test.c
@@ -223,6 +223,9 @@ int quicrq_test_loop_step(quicrq_test_config_t* config, int* is_active, uint64_t
         if (next_time > config->simulated_time) {
             config->simulated_time = next_time;
         }
+        else {
+            next_time = config->simulated_time;
+        }
         switch (next_step_type) {
         case 1:
             /* Simulate arrival of data for an object source */

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -305,7 +305,7 @@ int quicrq_congestion_test_one(int is_real_time, int use_datagrams, uint64_t sim
 
 int quicrq_congestion_basic_test()
 {
-    int ret = quicrq_congestion_test_one(1, 0, 0, 0, 80, 0x82);
+    int ret = quicrq_congestion_test_one(1, 0, 0, 0, 85, 0x82);
 
     return ret;
 }
@@ -319,7 +319,7 @@ int quicrq_congestion_basic_recv_test()
 
 int quicrq_congestion_basic_loss_test()
 {
-    int ret = quicrq_congestion_test_one(1, 0, 0x7080, 0, 161, 0x82);
+    int ret = quicrq_congestion_test_one(1, 0, 0x7080, 0, 180, 0x82);
 
     return ret;
 }
@@ -333,7 +333,7 @@ int quicrq_congestion_datagram_test()
 
 int quicrq_congestion_datagram_loss_test()
 {
-    int ret = quicrq_congestion_test_one(1, 1, 0x7080, 0, 110, 0x82);
+    int ret = quicrq_congestion_test_one(1, 1, 0x7080, 0, 115, 0x82);
 
     return ret;
 }
@@ -347,7 +347,7 @@ int quicrq_congestion_datagram_recv_test()
 
 int quicrq_congestion_datagram_rloss_test()
 {
-    int ret = quicrq_congestion_test_one(1, 1, 0x7080, 1, 110, 0x82);
+    int ret = quicrq_congestion_test_one(1, 1, 0x7080, 1, 115, 0x82);
 
     return ret;
 }

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -276,7 +276,7 @@ int quicrq_congestion_test_one(int is_real_time, int use_datagrams, uint64_t sim
             int observed_drops = 0;
             uint8_t observed_min_loss = 0xff;
 
-            ret = quicrq_compare_media_file_ex(result_file_name, media_source_path, &observed_drops, &observed_min_loss);
+            ret = quicrq_compare_media_file_ex(result_file_name, media_source_path, &observed_drops, &observed_min_loss, 0, 0);
 
             if (ret == 0) {
                 if (observed_drops > max_drops) {

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -326,7 +326,7 @@ int quicrq_congestion_basic_loss_test()
 
 int quicrq_congestion_datagram_test()
 {
-    int ret = quicrq_congestion_test_one(1, 1, 0, 0, 73, 0x82);
+    int ret = quicrq_congestion_test_one(1, 1, 0, 0, 82, 0x82);
 
     return ret;
 }
@@ -340,7 +340,7 @@ int quicrq_congestion_datagram_loss_test()
 
 int quicrq_congestion_datagram_recv_test()
 {
-    int ret = quicrq_congestion_test_one(1, 1, 0, 1, 75, 0x82);
+    int ret = quicrq_congestion_test_one(1, 1, 0, 1, 82, 0x82);
 
     return ret;
 }

--- a/tests/proto_test.c
+++ b/tests/proto_test.c
@@ -32,13 +32,15 @@ static quicrq_message_t stream_rq = {
     0,
     NULL,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t stream_rq_bytes[] = {
     QUICRQ_ACTION_REQUEST_STREAM,
     sizeof(url1),
-    URL1_BYTES
+    URL1_BYTES,
+    0x00
 };
 
 static quicrq_message_t datagram_rq = {
@@ -55,13 +57,69 @@ static quicrq_message_t datagram_rq = {
     0,
     NULL,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t datagram_rq_bytes[] = {
     QUICRQ_ACTION_REQUEST_DATAGRAM,
     sizeof(url1),
     URL1_BYTES,
+    0x00,
+    0x44, 0xd2
+};
+
+static quicrq_message_t datagram_rq_current_object = {
+    QUICRQ_ACTION_REQUEST_DATAGRAM,
+    sizeof(url1),
+    url1,
+    1234,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    NULL,
+    0,
+    0,
+    quicrq_subscribe_intent_current_object
+};
+
+static uint8_t datagram_rq_current_object_bytes[] = {
+    QUICRQ_ACTION_REQUEST_DATAGRAM,
+    sizeof(url1),
+    URL1_BYTES,
+    0x01,
+    0x44, 0xd2
+};
+
+static quicrq_message_t datagram_rq_start_point = {
+    QUICRQ_ACTION_REQUEST_DATAGRAM,
+    sizeof(url1),
+    url1,
+    1234,
+    4,
+    9,
+    0,
+    0,
+    0,
+    0,
+    0,
+    NULL,
+    0,
+    0,
+    quicrq_subscribe_intent_start_point
+};
+
+static uint8_t datagram_rq_start_point_bytes[] = {
+    QUICRQ_ACTION_REQUEST_DATAGRAM,
+    sizeof(url1),
+    URL1_BYTES,
+    0x02,
+    0x04,
+    0x09,
     0x44, 0xd2
 };
 
@@ -79,7 +137,8 @@ static quicrq_message_t fin_msg = {
     0,
     NULL,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t fin_msg_bytes[] = {
@@ -104,7 +163,8 @@ static quicrq_message_t repair_request_msg = {
     sizeof(repair_bytes),
     NULL,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t repair_request_msg_bytes[] = {
@@ -128,7 +188,8 @@ static quicrq_message_t fragment_msg = {
     sizeof(repair_bytes),
     repair_bytes,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t fragment_msg_bytes[] = {
@@ -155,7 +216,8 @@ static quicrq_message_t fragment_msg2 = {
     sizeof(repair_bytes),
     repair_bytes,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t fragment_msg2_bytes[] = {
@@ -183,7 +245,8 @@ static quicrq_message_t post_msg = {
     0,
     NULL,
     3,
-    1
+    1,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t post_msg_bytes[] = {
@@ -208,7 +271,8 @@ static quicrq_message_t accept_dg = {
     0,
     NULL,
     1,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t accept_dg_bytes[] = {
@@ -232,7 +296,8 @@ static quicrq_message_t accept_st = {
     0,
     NULL,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t accept_st_bytes[] = {
@@ -254,7 +319,8 @@ static quicrq_message_t start_msg = {
     0,
     NULL,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t start_msg_bytes[] = {
@@ -277,7 +343,8 @@ static quicrq_message_t subscribe_msg = {
     0,
     NULL,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t subscribe_msg_bytes[] = {
@@ -300,7 +367,8 @@ static quicrq_message_t notify_msg = {
     0,
     NULL,
     0,
-    0
+    0,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t notify_msg_bytes[] = {
@@ -324,7 +392,8 @@ static quicrq_message_t cache_policy_msg = {
     0,
     NULL,
     0,
-    1
+    1,
+    quicrq_subscribe_intent_current_group
 };
 
 static uint8_t cache_policy_bytes[] = {
@@ -344,6 +413,8 @@ typedef struct st_proto_test_case_t {
 static proto_test_case_t proto_cases[] = {
     PROTO_TEST_ITEM(stream_rq, stream_rq_bytes),
     PROTO_TEST_ITEM(datagram_rq, datagram_rq_bytes),
+    PROTO_TEST_ITEM(datagram_rq_current_object, datagram_rq_current_object_bytes),
+    PROTO_TEST_ITEM(datagram_rq_start_point, datagram_rq_start_point_bytes),
     PROTO_TEST_ITEM(fin_msg, fin_msg_bytes),
     PROTO_TEST_ITEM(repair_request_msg, repair_request_msg_bytes),
     PROTO_TEST_ITEM(fragment_msg, fragment_msg_bytes),
@@ -360,37 +431,43 @@ static proto_test_case_t proto_cases[] = {
 static uint8_t bad_bytes1[] = {
     0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     sizeof(url1),
-    URL1_BYTES
+    URL1_BYTES,
+    0x00
 };
 
 static uint8_t bad_bytes2[] = {
     QUICRQ_ACTION_REQUEST_STREAM,
     0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
-    URL1_BYTES
+    URL1_BYTES,
+    0x00
 };
 
 static uint8_t bad_bytes3[] = {
     QUICRQ_ACTION_REQUEST_STREAM,
     0x8f, 0xff, 0xff, 0xff,
-    URL1_BYTES
+    URL1_BYTES,
+    0x00
 };
 
 static uint8_t bad_bytes4[] = {
     QUICRQ_ACTION_REQUEST_STREAM,
     0x4f, 0xff,
-    URL1_BYTES
+    URL1_BYTES,
+    0x00
 };
 
 static uint8_t bad_bytes5[] = {
     QUICRQ_ACTION_REQUEST_STREAM,
     sizeof(url1) + 1,
     URL1_BYTES,
+    0x00
 };
 
 static uint8_t bad_bytes6[] = {
     QUICRQ_ACTION_REQUEST_DATAGRAM,
     0xcf, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
     URL1_BYTES,
+    0x00,
     0x44, 0xd2
 };
 
@@ -398,6 +475,7 @@ static uint8_t bad_bytes7[] = {
     QUICRQ_ACTION_REQUEST_DATAGRAM,
     0x8f, 0xff, 0xff, 0xff,
     URL1_BYTES,
+    0x00,
     0x44, 0xd2
 };
 
@@ -457,6 +535,51 @@ static uint8_t bad_bytes15[] = {
     0xff, 0xff
 };
 
+static uint8_t bad_bytes16[] = {
+    QUICRQ_ACTION_REQUEST_DATAGRAM,
+    sizeof(url1),
+    URL1_BYTES,
+    0x44, 0xd2
+};
+
+static uint8_t bad_bytes17[] = {
+    QUICRQ_ACTION_REQUEST_DATAGRAM,
+    sizeof(url1),
+    URL1_BYTES,
+    0x02,
+    0x44, 0xd2
+};
+
+static uint8_t bad_bytes18[] = {
+    QUICRQ_ACTION_REQUEST_DATAGRAM,
+    sizeof(url1),
+    URL1_BYTES,
+    0x02,
+    0x04,
+    0x44, 0xd2
+};
+
+static uint8_t bad_bytes19[] = {
+    QUICRQ_ACTION_REQUEST_DATAGRAM,
+    sizeof(url1),
+    URL1_BYTES,
+    0x03,
+    0x44, 0xd2
+};
+
+static uint8_t bad_bytes20[] = {
+    QUICRQ_ACTION_REQUEST_STREAM,
+    sizeof(url1),
+    URL1_BYTES
+};
+
+static uint8_t bad_bytes21[] = {
+    QUICRQ_ACTION_REQUEST_STREAM,
+    sizeof(url1),
+    URL1_BYTES,
+    0x03
+};
+
 typedef struct st_proto_test_bad_case_t {
     uint8_t* const data;
     size_t data_length;
@@ -481,7 +604,13 @@ static proto_test_bad_case_t proto_bad_cases[] = {
     PROTO_TEST_BAD_ITEM(bad_bytes12),
     PROTO_TEST_BAD_ITEM(bad_bytes13),
     PROTO_TEST_BAD_ITEM(bad_bytes14),
-    PROTO_TEST_BAD_ITEM(bad_bytes15)
+    PROTO_TEST_BAD_ITEM(bad_bytes15),
+    PROTO_TEST_BAD_ITEM(bad_bytes16),
+    PROTO_TEST_BAD_ITEM(bad_bytes17),
+    PROTO_TEST_BAD_ITEM(bad_bytes18),
+    PROTO_TEST_BAD_ITEM(bad_bytes19),
+    PROTO_TEST_BAD_ITEM(bad_bytes20),
+    PROTO_TEST_BAD_ITEM(bad_bytes21)
 };
 
 int proto_msg_test()
@@ -527,6 +656,9 @@ int proto_msg_test()
             ret = -1;
         }
         else if (result.is_last_fragment != proto_cases[i].result->is_last_fragment) {
+            ret = -1;
+        }
+        else if (result.subscribe_intent != proto_cases[i].result->subscribe_intent) {
             ret = -1;
         }
         else if (result.length != proto_cases[i].result->length) {

--- a/tests/proto_test.c
+++ b/tests/proto_test.c
@@ -69,7 +69,7 @@ static uint8_t datagram_rq_bytes[] = {
     0x44, 0xd2
 };
 
-static quicrq_message_t datagram_rq_current_object = {
+static quicrq_message_t datagram_rq_next_group = {
     QUICRQ_ACTION_REQUEST_DATAGRAM,
     sizeof(url1),
     url1,
@@ -84,10 +84,10 @@ static quicrq_message_t datagram_rq_current_object = {
     NULL,
     0,
     0,
-    quicrq_subscribe_intent_current_object
+    quicrq_subscribe_intent_next_group
 };
 
-static uint8_t datagram_rq_current_object_bytes[] = {
+static uint8_t datagram_rq_next_group_bytes[] = {
     QUICRQ_ACTION_REQUEST_DATAGRAM,
     sizeof(url1),
     URL1_BYTES,
@@ -413,7 +413,7 @@ typedef struct st_proto_test_case_t {
 static proto_test_case_t proto_cases[] = {
     PROTO_TEST_ITEM(stream_rq, stream_rq_bytes),
     PROTO_TEST_ITEM(datagram_rq, datagram_rq_bytes),
-    PROTO_TEST_ITEM(datagram_rq_current_object, datagram_rq_current_object_bytes),
+    PROTO_TEST_ITEM(datagram_rq_next_group, datagram_rq_next_group_bytes),
     PROTO_TEST_ITEM(datagram_rq_start_point, datagram_rq_start_point_bytes),
     PROTO_TEST_ITEM(fin_msg, fin_msg_bytes),
     PROTO_TEST_ITEM(repair_request_msg, repair_request_msg_bytes),

--- a/tests/proto_test.c
+++ b/tests/proto_test.c
@@ -183,14 +183,15 @@ static quicrq_message_t post_msg = {
     0,
     NULL,
     3,
-    0
+    1
 };
 
 static uint8_t post_msg_bytes[] = {
     QUICRQ_ACTION_POST,
     sizeof(url1),
     URL1_BYTES,
-    3
+    3,
+    1
 };
 
 static quicrq_message_t accept_dg = {

--- a/tests/proto_test.c
+++ b/tests/proto_test.c
@@ -31,6 +31,7 @@ static quicrq_message_t stream_rq = {
     0,
     0,
     NULL,
+    0,
     0
 };
 
@@ -53,6 +54,7 @@ static quicrq_message_t datagram_rq = {
     0,
     0,
     NULL,
+    0,
     0
 };
 
@@ -76,6 +78,7 @@ static quicrq_message_t fin_msg = {
     0,
     0,
     NULL,
+    0,
     0
 };
 
@@ -100,6 +103,7 @@ static quicrq_message_t repair_request_msg = {
     1,
     sizeof(repair_bytes),
     NULL,
+    0,
     0
 };
 
@@ -123,6 +127,7 @@ static quicrq_message_t fragment_msg = {
     1,
     sizeof(repair_bytes),
     repair_bytes,
+    0,
     0
 };
 
@@ -149,6 +154,7 @@ static quicrq_message_t fragment_msg2 = {
     1,
     sizeof(repair_bytes),
     repair_bytes,
+    0,
     0
 };
 
@@ -176,7 +182,8 @@ static quicrq_message_t post_msg = {
     0,
     0,
     NULL,
-    3
+    3,
+    0
 };
 
 static uint8_t post_msg_bytes[] = {
@@ -199,7 +206,8 @@ static quicrq_message_t accept_dg = {
     0,
     0,
     NULL,
-    1
+    1,
+    0
 };
 
 static uint8_t accept_dg_bytes[] = {
@@ -222,6 +230,7 @@ static quicrq_message_t accept_st = {
     0,
     0,
     NULL,
+    0,
     0
 };
 
@@ -229,7 +238,6 @@ static uint8_t accept_st_bytes[] = {
     QUICRQ_ACTION_ACCEPT,
     0
 };
-
 
 static quicrq_message_t start_msg = {
     QUICRQ_ACTION_START_POINT,
@@ -244,6 +252,7 @@ static quicrq_message_t start_msg = {
     0,
     0,
     NULL,
+    0,
     0
 };
 
@@ -266,6 +275,7 @@ static quicrq_message_t subscribe_msg = {
     0,
     0,
     NULL,
+    0,
     0
 };
 
@@ -288,6 +298,7 @@ static quicrq_message_t notify_msg = {
     0,
     0,
     NULL,
+    0,
     0
 };
 
@@ -296,6 +307,31 @@ static uint8_t notify_msg_bytes[] = {
     sizeof(url1),
     URL1_BYTES
 };
+
+
+static quicrq_message_t cache_policy_msg = {
+    QUICRQ_ACTION_CACHE_POLICY,
+    0,
+    NULL,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    NULL,
+    0,
+    1
+};
+
+static uint8_t cache_policy_bytes[] = {
+    QUICRQ_ACTION_CACHE_POLICY,
+    1
+};
+
+
 
 typedef struct st_proto_test_case_t {
     uint8_t* const data;
@@ -316,7 +352,8 @@ static proto_test_case_t proto_cases[] = {
     PROTO_TEST_ITEM(accept_st, accept_st_bytes),
     PROTO_TEST_ITEM(start_msg, start_msg_bytes),
     PROTO_TEST_ITEM(subscribe_msg, subscribe_msg_bytes),
-    PROTO_TEST_ITEM(notify_msg, notify_msg_bytes)
+    PROTO_TEST_ITEM(notify_msg, notify_msg_bytes),
+    PROTO_TEST_ITEM(cache_policy_msg, cache_policy_bytes)
 };
 
 static uint8_t bad_bytes1[] = {

--- a/tests/quicrq_test_internal.h
+++ b/tests/quicrq_test_internal.h
@@ -85,6 +85,7 @@ typedef struct st_test_media_object_source_context_t {
 typedef struct st_quicrq_test_config_t {
     uint64_t simulated_time;
     uint64_t simulate_loss;
+    uint64_t next_test_event_time;
     char test_server_cert_file[512];
     char test_server_key_file[512];
     char test_server_cert_store_file[512];
@@ -172,6 +173,8 @@ void* test_media_publisher_init(char const* media_source_path, const generation_
 void* test_media_consumer_init(char const* media_result_file, char const* media_result_log);
 int test_media_consumer_init_callback(quicrq_stream_ctx_t* stream_ctx, const uint8_t* url, size_t url_length);
 test_object_stream_ctx_t* test_object_stream_subscribe(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length, int use_datagrams, char const* media_result_file, char const* media_result_log);
+test_object_stream_ctx_t* test_object_stream_subscribe_ex(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length, int use_datagrams,
+    quicrq_subscribe_intent_t* intent, char const* media_result_file, char const* media_result_log);
 int test_media_object_source_iterate(test_media_object_source_context_t* object_pub_ctx, uint64_t current_time, int * is_active);
 uint64_t test_media_object_source_next_time(test_media_object_source_context_t* object_pub_ctx, uint64_t current_time);
 void test_media_object_source_delete(test_media_object_source_context_t* object_pub_ctx);

--- a/tests/quicrq_test_internal.h
+++ b/tests/quicrq_test_internal.h
@@ -141,7 +141,8 @@ extern const generation_parameters_t video_1mps;
 
 int test_media_subscribe(quicrq_cnx_ctx_t* cnx_ctx, uint8_t* url, size_t url_length, int use_datagrams, char const* media_result_file, char const* media_result_log);
 int quicrq_compare_media_file(char const* media_result_file, char const* media_reference_file);
-int quicrq_compare_media_file_ex(char const* media_result_file, char const* media_reference_file, int* nb_losses, uint8_t* loss_flag);
+int quicrq_compare_media_file_ex(char const* media_result_file, char const* media_reference_file,
+    int* nb_losses, uint8_t* loss_flag, uint64_t start_group_id, uint64_t start_object_id);
 int test_media_is_audio(const uint8_t* url, size_t url_length);
 
 typedef struct st_test_object_stream_ctx_t {

--- a/tests/quicrq_test_internal.h
+++ b/tests/quicrq_test_internal.h
@@ -177,6 +177,9 @@ uint64_t test_media_object_source_next_time(test_media_object_source_context_t* 
 void test_media_object_source_delete(test_media_object_source_context_t* object_pub_ctx);
 test_media_object_source_context_t* test_media_object_source_publish(quicrq_ctx_t* qr_ctx, uint8_t* url, size_t url_length, char const* media_source_path,
     const generation_parameters_t* generation_model, int is_real_time, uint64_t start_time);
+test_media_object_source_context_t* test_media_object_source_publish_ex(quicrq_ctx_t* qr_ctx, uint8_t* url, size_t url_length,
+    char const* media_source_path, const generation_parameters_t* generation_model, int is_real_time,
+    uint64_t start_time, quicrq_media_object_source_properties_t* properties);
 int test_media_object_source_set_start(test_media_object_source_context_t* object_pub_ctx, uint64_t start_group, uint64_t start_object);
 
 int test_media_derive_file_names(const uint8_t* url, size_t url_length, int is_datagram, int is_real_time, int is_post,

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -53,6 +53,7 @@ extern "C" {
     int quicrq_triangle_datagram_extra_test();
     int quicrq_triangle_start_point_test();
     int quicrq_triangle_cache_test();
+    int quicrq_triangle_cache_stream_test();
     int quicrq_pyramid_basic_test();
     int quicrq_pyramid_datagram_test();
     int quicrq_pyramid_datagram_loss_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -56,6 +56,7 @@ extern "C" {
     int quicrq_triangle_cache_loss_test();
     int quicrq_triangle_cache_stream_test();
     int quicrq_triangle_intent_test();
+    int quicrq_triangle_intent_datagram_test();
     int quicrq_pyramid_basic_test();
     int quicrq_pyramid_datagram_test();
     int quicrq_pyramid_datagram_loss_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -55,6 +55,7 @@ extern "C" {
     int quicrq_triangle_cache_test();
     int quicrq_triangle_cache_loss_test();
     int quicrq_triangle_cache_stream_test();
+    int quicrq_triangle_intent_test();
     int quicrq_pyramid_basic_test();
     int quicrq_pyramid_datagram_test();
     int quicrq_pyramid_datagram_loss_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -53,6 +53,7 @@ extern "C" {
     int quicrq_triangle_datagram_extra_test();
     int quicrq_triangle_start_point_test();
     int quicrq_triangle_cache_test();
+    int quicrq_triangle_cache_loss_test();
     int quicrq_triangle_cache_stream_test();
     int quicrq_pyramid_basic_test();
     int quicrq_pyramid_datagram_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -57,6 +57,7 @@ extern "C" {
     int quicrq_triangle_cache_stream_test();
     int quicrq_triangle_intent_test();
     int quicrq_triangle_intent_datagram_test();
+    int quicrq_triangle_intent_loss_test();
     int quicrq_pyramid_basic_test();
     int quicrq_pyramid_datagram_test();
     int quicrq_pyramid_datagram_loss_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -58,6 +58,7 @@ extern "C" {
     int quicrq_triangle_intent_test();
     int quicrq_triangle_intent_datagram_test();
     int quicrq_triangle_intent_loss_test();
+    int quicrq_triangle_intent_next_test();
     int quicrq_pyramid_basic_test();
     int quicrq_pyramid_datagram_test();
     int quicrq_pyramid_datagram_loss_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -60,6 +60,8 @@ extern "C" {
     int quicrq_triangle_intent_loss_test();
     int quicrq_triangle_intent_next_test();
     int quicrq_triangle_intent_next_s_test();
+    int quicrq_triangle_intent_that_test();
+    int quicrq_triangle_intent_that_s_test();
     int quicrq_pyramid_basic_test();
     int quicrq_pyramid_datagram_test();
     int quicrq_pyramid_datagram_loss_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -59,6 +59,7 @@ extern "C" {
     int quicrq_triangle_intent_datagram_test();
     int quicrq_triangle_intent_loss_test();
     int quicrq_triangle_intent_next_test();
+    int quicrq_triangle_intent_next_s_test();
     int quicrq_pyramid_basic_test();
     int quicrq_pyramid_datagram_test();
     int quicrq_pyramid_datagram_loss_test();

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -815,7 +815,7 @@ int test_media_object_consumer_cb(
         }
         break;
     case quicrq_media_start_point:
-        ret = quicrq_reassembly_learn_start_point(&cons_ctx->reassembly_ctx, object_id, current_time,
+        ret = quicrq_reassembly_learn_start_point(&cons_ctx->reassembly_ctx, group_id, object_id, current_time,
             test_media_consumer_object_ready, cons_ctx);
         if (ret == 0 && cons_ctx->reassembly_ctx.is_finished) {
             ret = quicrq_consumer_finished;

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -956,7 +956,8 @@ int test_object_stream_consumer_cb(
     return ret;
 }
 
-test_object_stream_ctx_t* test_object_stream_subscribe(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length, int use_datagrams, char const* media_result_file, char const* media_result_log)
+test_object_stream_ctx_t* test_object_stream_subscribe_ex(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length, int use_datagrams,
+    quicrq_subscribe_intent_t * intent, char const* media_result_file, char const* media_result_log)
 {
     int ret = 0;
     /* Open and initialize result file and log file */
@@ -975,7 +976,7 @@ test_object_stream_ctx_t* test_object_stream_subscribe(quicrq_cnx_ctx_t* cnx_ctx
             ret = -1;
         }
         else {
-            cons_ctx->media_ctx = quicrq_subscribe_object_stream(cnx_ctx, url, url_length, use_datagrams, 1, test_object_stream_consumer_cb, cons_ctx);
+            cons_ctx->media_ctx = quicrq_subscribe_object_stream(cnx_ctx, url, url_length, use_datagrams, 1, intent, test_object_stream_consumer_cb, cons_ctx);
             if (cons_ctx->media_ctx == NULL) {
                 ret = -1;
             }
@@ -989,6 +990,12 @@ test_object_stream_ctx_t* test_object_stream_subscribe(quicrq_cnx_ctx_t* cnx_ctx
     return cons_ctx;
 }
 
+test_object_stream_ctx_t* test_object_stream_subscribe(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length, int use_datagrams,
+    char const* media_result_file, char const* media_result_log)
+{
+    return test_object_stream_subscribe_ex(cnx_ctx, url, url_length, use_datagrams,
+        NULL, media_result_file, media_result_log);
+}
 
 /* Compare media file.
  * These are binary files composed of sequences of objects.

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -816,6 +816,9 @@ int test_media_object_consumer_cb(
     case quicrq_media_close:
         ret = test_media_consumer_close(media_ctx);
         break;
+    case quicrq_media_real_time_cache:
+        /* Ignore that for now */
+        break;
     default:
         ret = -1;
         break;

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -554,17 +554,18 @@ int test_media_is_audio(const uint8_t* url, size_t url_length)
     return is_audio;
 }
 
-test_media_object_source_context_t* test_media_object_source_publish(quicrq_ctx_t* qr_ctx, uint8_t* url, size_t url_length,
+test_media_object_source_context_t* test_media_object_source_publish_ex(quicrq_ctx_t* qr_ctx, uint8_t* url, size_t url_length,
     char const* media_source_path, const generation_parameters_t* generation_model, int is_real_time,
-    uint64_t start_time)
+    uint64_t start_time, quicrq_media_object_source_properties_t * properties)
 {
+
     test_media_object_source_context_t* object_pub_ctx = (test_media_object_source_context_t*)malloc(
         sizeof(test_media_object_source_context_t));
     if (object_pub_ctx != NULL) {
         memset(object_pub_ctx, 0, sizeof(test_media_object_source_context_t));
         object_pub_ctx->pub_ctx =
             test_media_publisher_init(media_source_path, generation_model, is_real_time, start_time);
-        object_pub_ctx->object_source_ctx = quicrq_publish_object_source(qr_ctx, url, url_length, NULL);
+        object_pub_ctx->object_source_ctx = quicrq_publish_object_source(qr_ctx, url, url_length, properties);
 
         if (object_pub_ctx->pub_ctx == NULL || object_pub_ctx->object_source_ctx == NULL) {
             test_media_object_source_delete(object_pub_ctx);
@@ -577,6 +578,13 @@ test_media_object_source_context_t* test_media_object_source_publish(quicrq_ctx_
         }
     }
     return object_pub_ctx;
+}
+
+test_media_object_source_context_t* test_media_object_source_publish(quicrq_ctx_t* qr_ctx, uint8_t* url, size_t url_length,
+    char const* media_source_path, const generation_parameters_t* generation_model, int is_real_time,
+    uint64_t start_time)
+{
+    return test_media_object_source_publish_ex(qr_ctx, url, url_length, media_source_path, generation_model, is_real_time, start_time, NULL);
 }
 
 int test_media_object_source_set_start(test_media_object_source_context_t* object_pub_ctx, uint64_t start_group, uint64_t start_object)

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -430,3 +430,10 @@ int quicrq_triangle_intent_next_test()
 
     return ret;
 }
+
+int quicrq_triangle_intent_next_s_test()
+{
+    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1, 2);
+
+    return ret;
+}

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -116,9 +116,16 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
 
     if (ret == 0) {
         /* Add a test source to the configuration on client #1 (publisher) */
+        quicrq_media_object_source_properties_t properties = { 0 };
         int publish_node = 1;
-        config->object_sources[0] = test_media_object_source_publish(config->nodes[publish_node], (uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
-            strlen(QUICRQ_TEST_BASIC_SOURCE), media_source_path, NULL, is_real_time, config->simulated_time);
+
+        if (test_cache_clear) {
+            properties.use_real_time_caching = 1;
+            quicrq_set_cache_duration(config->nodes[0], 5000000);
+        }
+
+        config->object_sources[0] = test_media_object_source_publish_ex(config->nodes[publish_node], (uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
+            strlen(QUICRQ_TEST_BASIC_SOURCE), media_source_path, NULL, is_real_time, config->simulated_time, &properties);
         if (config->object_sources[0] == NULL) {
             ret = -1;
         }
@@ -327,6 +334,13 @@ int quicrq_triangle_start_point_test()
 int quicrq_triangle_cache_test()
 {
     int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 1);
+
+    return ret;
+}
+
+int quicrq_triangle_cache_stream_test()
+{
+    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1);
 
     return ret;
 }

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -192,6 +192,25 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
             /* Create a subscription to the test source on client # 2*/
             test_object_stream_ctx_t* object_stream_ctx = NULL;
             quicrq_subscribe_intent_t intent = { 0 };
+            intent.intent_mode = (quicrq_subscribe_intent_enum)(test_intent - 1);
+            switch (intent.intent_mode) {
+            case quicrq_subscribe_intent_current_group:
+                start_group_intent = 1;
+                start_object_intent = 0;
+                break;
+            case quicrq_subscribe_intent_next_group:
+                start_group_intent = 2;
+                start_object_intent = 0;
+                break;
+            case quicrq_subscribe_intent_start_point:
+                intent.start_group_id = 1;
+                intent.start_object_id = 2;
+                start_group_intent =  intent.start_group_id;
+                start_object_intent = intent.start_object_id;
+                break;
+            default:
+                break;
+            }
             object_stream_ctx = test_object_stream_subscribe_ex(cnx_ctx_2, (const uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
                 strlen(QUICRQ_TEST_BASIC_SOURCE), use_datagrams, &intent, result_file_name, result_log_name);
             if (object_stream_ctx == NULL) {
@@ -202,10 +221,6 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
                 subscribed = 1;
             }
             config->next_test_event_time = UINT64_MAX;
-            if (intent.intent_mode == quicrq_subscribe_intent_current_group) {
-                start_group_intent = 1;
-                start_object_intent = 0;
-            }
         }
 
         ret = quicrq_test_loop_step(config, &is_active, UINT64_MAX);
@@ -404,7 +419,14 @@ int quicrq_triangle_intent_datagram_test()
 
 int quicrq_triangle_intent_loss_test()
 {
-    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 0, 0, 0, 1);
+    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 0, 0, 1, 1);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_next_test()
+{
+    int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 1, 2);
 
     return ret;
 }

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -437,3 +437,17 @@ int quicrq_triangle_intent_next_s_test()
 
     return ret;
 }
+
+int quicrq_triangle_intent_that_test()
+{
+    int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 1, 3);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_that_s_test()
+{
+    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1, 3);
+
+    return ret;
+}

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -338,6 +338,13 @@ int quicrq_triangle_cache_test()
     return ret;
 }
 
+int quicrq_triangle_cache_loss_test()
+{
+    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 0, 0, 1);
+
+    return ret;
+}
+
 int quicrq_triangle_cache_stream_test()
 {
     int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1);

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -353,6 +353,13 @@ int quicrq_triangle_datagram_extra_test()
     return ret;
 }
 
+/* The start point test verifies what happens if a source does not start
+ * at Group=0, Object=0. That would be, for example, a source resuming
+ * after a hiatus. This test will have to be rewritten after we change
+ * the "object source" API to let publishers explicitly specify the
+ * group and object ID.
+ * It is disabled for now.
+ */
 int quicrq_triangle_start_point_test()
 {
     int ret = quicrq_triangle_test_one(1, 1, 0x7080, 10000, 12345, 0, 0);
@@ -382,6 +389,13 @@ int quicrq_triangle_cache_stream_test()
 }
 
 int quicrq_triangle_intent_test()
+{
+    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1, 1);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_datagram_test()
 {
     int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1, 1);
 

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -397,7 +397,14 @@ int quicrq_triangle_intent_test()
 
 int quicrq_triangle_intent_datagram_test()
 {
-    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1, 1);
+    int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 1, 1);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_loss_test()
+{
+    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 0, 0, 0, 1);
 
     return ret;
 }

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -65,7 +65,8 @@ quicrq_test_config_t* quicrq_test_triangle_config_create(uint64_t simulate_loss,
 }
 
 /* Basic relay test */
-int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simulate_losses, uint64_t extra_delay, uint64_t start_point, int test_cache_clear)
+int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simulate_losses, uint64_t extra_delay, uint64_t start_point,
+    int test_cache_clear, int test_intent)
 {
     int ret = 0;
     int nb_steps = 0;
@@ -83,9 +84,10 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
     size_t nb_log_chars = 0;
     int partial_closure = 0;
     uint64_t client2_close_time = UINT64_MAX;
+    int subscribed = 0;
 
-    (void)picoquic_sprintf(text_log_name, sizeof(text_log_name), &nb_log_chars, "triangle_textlog-%d-%d-%llx-%llu-%llu-%d.txt", is_real_time, use_datagrams,
-        (unsigned long long)simulate_losses, (unsigned long long) extra_delay, (unsigned long long) start_point, test_cache_clear);
+    (void)picoquic_sprintf(text_log_name, sizeof(text_log_name), &nb_log_chars, "triangle_textlog-%d-%d-%llx-%llu-%llu-%d-%d.txt", is_real_time, use_datagrams,
+        (unsigned long long)simulate_losses, (unsigned long long) extra_delay, (unsigned long long) start_point, test_cache_clear, test_intent);
     /* TODO: name shall indicate the triangle configuration */
     ret = test_media_derive_file_names((uint8_t*)QUICRQ_TEST_BASIC_SOURCE, strlen(QUICRQ_TEST_BASIC_SOURCE),
         use_datagrams, is_real_time, 1,
@@ -119,7 +121,7 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
         quicrq_media_object_source_properties_t properties = { 0 };
         int publish_node = 1;
 
-        if (test_cache_clear) {
+        if (test_cache_clear || test_intent > 0) {
             properties.use_real_time_caching = 1;
             quicrq_set_cache_duration(config->nodes[0], 5000000);
         }
@@ -161,24 +163,44 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
     }
 
     if (ret == 0) {
-        /* Create a subscription to the test source on client # 2*/
-        if (ret == 0) {
+        if (test_intent > 0) {
+            config->next_test_event_time = 4000000;
+        } else {
+            /* Create a subscription to the test source on client # 2*/
             test_object_stream_ctx_t* object_stream_ctx = NULL;
             object_stream_ctx = test_object_stream_subscribe(cnx_ctx_2, (const uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
                 strlen(QUICRQ_TEST_BASIC_SOURCE), use_datagrams, result_file_name, result_log_name);
             if (object_stream_ctx == NULL) {
                 ret = -1;
             }
-        }
-        if (ret != 0) {
-            DBG_PRINTF("Cannot subscribe to test media %s, ret = %d", QUICRQ_TEST_BASIC_SOURCE, ret);
+            else {
+                subscribed = 1;
+            }
+            if (ret != 0) {
+                DBG_PRINTF("Cannot subscribe to test media %s, ret = %d", QUICRQ_TEST_BASIC_SOURCE, ret);
+            }
         }
     }
-
 
     while (ret == 0 && nb_inactive < max_inactive && config->simulated_time < max_time) {
         /* Run the simulation. Monitor the connection. Monitor the media. */
         int is_active = 0;
+
+        if (!subscribed && config->simulated_time >= config->next_test_event_time) {
+            /* Create a subscription to the test source on client # 2*/
+            test_object_stream_ctx_t* object_stream_ctx = NULL;
+            quicrq_subscribe_intent_t intent = { 0 };
+            object_stream_ctx = test_object_stream_subscribe_ex(cnx_ctx_2, (const uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
+                strlen(QUICRQ_TEST_BASIC_SOURCE), use_datagrams, &intent, result_file_name, result_log_name);
+            if (object_stream_ctx == NULL) {
+                ret = -1;
+                break;
+            }
+            else {
+                subscribed = 1;
+            }
+            config->next_test_event_time = UINT64_MAX;
+        }
 
         ret = quicrq_test_loop_step(config, &is_active, UINT64_MAX);
         if (ret != 0) {
@@ -204,7 +226,8 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
         else {
             /* TODO: add closing condition on server */
             int client1_stream_closed = config->nodes[1]->first_cnx == NULL || config->nodes[1]->first_cnx->first_stream == NULL;
-            int client2_stream_closed = config->nodes[2]->first_cnx == NULL || config->nodes[2]->first_cnx->first_stream == NULL;
+            int client2_stream_closed = config->nodes[2]->first_cnx == NULL ||
+                (config->nodes[2]->first_cnx->first_stream == NULL && subscribed);
 
             if (client2_stream_closed && client2_close_time > config->simulated_time) {
                 client2_close_time = config->simulated_time;
@@ -291,63 +314,70 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
 
 int quicrq_triangle_basic_test()
 {
-    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 0);
+    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 0, 0);
 
     return ret;
 }
 
 int quicrq_triangle_basic_loss_test()
 {
-    int ret = quicrq_triangle_test_one(1, 0, 0x7080, 0, 0, 0);
+    int ret = quicrq_triangle_test_one(1, 0, 0x7080, 0, 0, 0, 0);
 
     return ret;
 }
 
 int quicrq_triangle_datagram_test()
 {
-    int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 0);
+    int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 0, 0);
 
     return ret;
 }
 
 int quicrq_triangle_datagram_loss_test()
 {
-    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 0, 0, 0);
+    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 0, 0, 0, 0);
 
     return ret;
 }
 
 int quicrq_triangle_datagram_extra_test()
 {
-    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 10000, 0, 0);
+    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 10000, 0, 0, 0);
 
     return ret;
 }
 
 int quicrq_triangle_start_point_test()
 {
-    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 10000, 12345, 0);
+    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 10000, 12345, 0, 0);
 
     return ret;
 }
 
 int quicrq_triangle_cache_test()
 {
-    int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 1);
+    int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 1, 0);
 
     return ret;
 }
 
 int quicrq_triangle_cache_loss_test()
 {
-    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 0, 0, 1);
+    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 0, 0, 1, 0);
 
     return ret;
 }
 
 int quicrq_triangle_cache_stream_test()
 {
-    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1);
+    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1, 0);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_test()
+{
+    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1, 1);
 
     return ret;
 }

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -85,6 +85,8 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
     int partial_closure = 0;
     uint64_t client2_close_time = UINT64_MAX;
     int subscribed = 0;
+    uint64_t start_group_intent = 0;
+    uint64_t start_object_intent = 0;
 
     (void)picoquic_sprintf(text_log_name, sizeof(text_log_name), &nb_log_chars, "triangle_textlog-%d-%d-%llx-%llu-%llu-%d-%d.txt", is_real_time, use_datagrams,
         (unsigned long long)simulate_losses, (unsigned long long) extra_delay, (unsigned long long) start_point, test_cache_clear, test_intent);
@@ -200,6 +202,10 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
                 subscribed = 1;
             }
             config->next_test_event_time = UINT64_MAX;
+            if (intent.intent_mode == quicrq_subscribe_intent_current_group) {
+                start_group_intent = 1;
+                start_object_intent = 0;
+            }
         }
 
         ret = quicrq_test_loop_step(config, &is_active, UINT64_MAX);
@@ -303,7 +309,7 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
     }
     /* Verify that media file was received correctly */
     if (ret == 0) {
-        ret = quicrq_compare_media_file(result_file_name, media_source_path);
+        ret = quicrq_compare_media_file_ex(result_file_name, media_source_path, NULL, NULL, start_group_intent, start_object_intent);
     }
     else {
         DBG_PRINTF("Test failed before getting results, ret = %d", ret);


### PR DESCRIPTION
Implementing the "subscribe intent" logic will take two steps.

The first step is to revise the cache management to distinguish between "streaming" media, for which the cache shall always start at the beginning, and "real time" media, for which the cache is purged progressively as time passes, while keeping the relevant GOB in cache. The first series of commit implement that. The only API change is the addition of a media source property describing the required cache management.

Next, we have to consider "intent". By default, this means that for real time media, transmission to a new client will start at the latest GOB, with code to drop intermediate frames marked as "can be dropped". This will come next.

After that, two plausible variations: let the client specify the GOB/Object ID at which it wants to start receiving; and let the client specify a "next GOB" mode if it does not want to receive partial data.