### PR TITLE
Explicit object numbers

### DIFF
--- a/.github/workflows/test-clang.yml
+++ b/.github/workflows/test-clang.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Build quicrq
         run: |
-          brew reinstall openssl
+          # brew reinstall openssl
+          apt reinstall openssl
           export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
           cmake -S . -B build
           cmake --build build

--- a/.github/workflows/test-clang.yml
+++ b/.github/workflows/test-clang.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Build quicrq
         run: |
           # brew reinstall openssl
-          apt reinstall openssl
           export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
           cmake -S . -B build
           cmake --build build

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -23,6 +23,8 @@ jobs:
 
       - name: Build quicrq
         run: |
+          echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> /Users/homefolder/.zprofile
+          eval $(/opt/homebrew/bin/brew shellenv)
           brew reinstall openssl
           export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
           cmake -S . -B build

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -23,9 +23,7 @@ jobs:
 
       - name: Build quicrq
         run: |
-          echo 'eval $(/opt/homebrew/bin/brew shellenv)' >> /Users/homefolder/.zprofile
-          eval $(/opt/homebrew/bin/brew shellenv)
-          brew reinstall openssl
+          # brew reinstall openssl
           export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
           cmake -S . -B build
           cmake --build build

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -287,14 +287,18 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
-#if 0
-		/* Start point function needs to be revised after "subscriber intent" */
 		TEST_METHOD(triangle_start_point) {
 			int ret = quicrq_triangle_start_point_test();
 
 			Assert::AreEqual(ret, 0);
 		}
-#endif
+
+		TEST_METHOD(triangle_start_point_s) {
+			int ret = quicrq_triangle_start_point_s_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(triangle_cache) {
 			int ret = quicrq_triangle_cache_test();
 

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -14,7 +14,7 @@ extern "C" {
  * The minor version is updated when the protocol changes
  * Only the letter is updated if the code changes without changing the protocol
  */
-#define QUICRQ_VERSION "0.23"
+#define QUICRQ_VERSION "0.24"
 
 /* QUICR ALPN and QUICR port
  * For version zero, the ALPN is set to "quicr-h<minor>", where <minor> is
@@ -22,7 +22,7 @@ extern "C" {
  * different protocol versions will not be compatible, and connections attempts
  * between such binaries will fail, forcing deployments of compatible versions.
  */
-#define QUICRQ_ALPN "quicr-h23"
+#define QUICRQ_ALPN "quicr-h24"
 #define QUICRQ_PORT 853
 
 /* QUICR error codes */

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -88,9 +88,6 @@ typedef struct st_quicrq_media_object_header_t {
 } quicrq_media_object_header_t;
 
 /* Media object publisher.
- * The media object publisher is a simpler, object based version of the 
- * media object API described below. It is push based, while the media
- * API is pull based.
  * 
  * The API has three components:
  * - Publish media object source: declare the URL of the source, and 
@@ -108,8 +105,21 @@ typedef struct st_quicrq_media_object_header_t {
  * is posted. The cache management policy is specified upon opening
  * the object.
  * 
- * The API is implemented using the "media publisher" API. It defines
- * generic media_publisher_subscribe_fn and media_publisher_fn.
+ * In the "quicrq_publish_object" function, the application provides
+ * the group_id and object_id of the published object. The application
+ * MUST generate these numbers according to the following rules:
+ * 
+ * - if this is the first call to the API, the application
+ *   can pick any value it wants. This is equivalent to
+ *   calling the `quicrq_object_source_set_start` function
+ *   with the same values.
+ * - For subsequent calls, either the group_id or the object_id
+ *   MUST be incremented in sequence, as follow:
+ *     * If the group_id does not match the previous value,
+ *       it MUST be set to previous group ID plus 1, and the
+ *       object ID MUST be set to 0.
+ *     * if the group_id matches the previous value, the
+ *       object ID MUST be set to previous value + 1.
  */
 
 typedef struct st_quicrq_media_object_source_properties_t {
@@ -132,10 +142,9 @@ int quicrq_publish_object(
     quicrq_media_object_source_ctx_t* object_source_ctx,
     uint8_t* object,
     size_t object_length,
-    int is_new_group,
     quicrq_media_object_properties_t * properties,
-    uint64_t* published_group_id,
-    uint64_t* published_object_id);
+    uint64_t group_id,
+    uint64_t object_id);
 
 void quicrq_publish_object_fin(quicrq_media_object_source_ctx_t* object_source_ctx);
 

--- a/lib/proto.c
+++ b/lib/proto.c
@@ -1090,7 +1090,10 @@ int quicrq_cnx_post_accepted(quicrq_stream_ctx_t* stream_ctx, unsigned int use_d
         stream_ctx->datagram_stream_id = datagram_stream_id;
         stream_ctx->send_state = quicrq_sending_ready;
         stream_ctx->receive_state = quicrq_receive_done;
-        picoquic_mark_active_stream(stream_ctx->cnx_ctx->cnx, stream_ctx->stream_id, 0, stream_ctx);
+        /* Maybe we need to send policy messages, in which case the stream should be active! */
+        int more_to_send = (!stream_ctx->is_start_object_id_sent && (stream_ctx->start_group_id > 0 || stream_ctx->start_object_id > 0));
+        more_to_send |= (!stream_ctx->is_cache_policy_sent && stream_ctx->is_cache_real_time);
+        picoquic_mark_active_stream(stream_ctx->cnx_ctx->cnx, stream_ctx->stream_id, more_to_send, stream_ctx);
     }
     else {
         stream_ctx->is_datagram = 0;

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -66,10 +66,8 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_datagram", quicrq_triangle_datagram_test },
     { "triangle_datagram_loss", quicrq_triangle_datagram_loss_test },
     { "triangle_datagram_extra", quicrq_triangle_datagram_extra_test },
-#if 0
-    /* Start point function is superceded by "subscribe intent" */
     { "triangle_start_point", quicrq_triangle_start_point_test },
-#endif
+    { "triangle_start_point_s", quicrq_triangle_start_point_s_test },
     { "triangle_cache", quicrq_triangle_cache_test },
     { "triangle_cache_loss", quicrq_triangle_cache_loss_test },
     { "triangle_cache_stream", quicrq_triangle_cache_stream_test },

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -52,6 +52,7 @@ extern "C" {
     int quicrq_triangle_datagram_loss_test();
     int quicrq_triangle_datagram_extra_test();
     int quicrq_triangle_start_point_test();
+    int quicrq_triangle_start_point_s_test();
     int quicrq_triangle_cache_test();
     int quicrq_triangle_cache_loss_test();
     int quicrq_triangle_cache_stream_test();

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -133,8 +133,10 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
         if (config->object_sources[0] == NULL) {
             ret = -1;
         }
-        else if (start_point > 0) {
-            ret = test_media_object_source_set_start(config->object_sources[0], 0, start_point);
+        else if (start_point != 0) {
+            ret = test_media_object_source_set_start(config->object_sources[0], 1, 1);
+            start_group_intent = 1;
+            start_object_intent = 1;
         }
     }
 
@@ -377,7 +379,14 @@ int quicrq_triangle_datagram_extra_test()
  */
 int quicrq_triangle_start_point_test()
 {
-    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 10000, 12345, 0, 0);
+    int ret = quicrq_triangle_test_one(1, 1, 0x7080, 10000, 1, 0, 0);
+
+    return ret;
+}
+
+int quicrq_triangle_start_point_s_test()
+{
+    int ret = quicrq_triangle_test_one(1, 0, 0x7080, 10000, 1, 0, 0);
 
     return ret;
 }


### PR DESCRIPTION
Modify the "object source publish" API to specify explicitly the group_id and object_id of the object being published. The numbers chosen by the application must follow the sequencing logic.

Also validate the tests for the "start point" API. The tests are implemented with the modified object source publish API. 