### PR TITLE
Post as publish

### DIFF
--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -14,7 +14,7 @@ extern "C" {
  * The minor version is updated when the protocol changes
  * Only the letter is updated if the code changes without changing the protocol
  */
-#define QUICRQ_VERSION "0.24b"
+#define QUICRQ_VERSION "0.25"
 
 /* QUICR ALPN and QUICR port
  * For version zero, the ALPN is set to "quicr-h<minor>", where <minor> is
@@ -22,7 +22,7 @@ extern "C" {
  * different protocol versions will not be compatible, and connections attempts
  * between such binaries will fail, forcing deployments of compatible versions.
  */
-#define QUICRQ_ALPN "quicr-h24"
+#define QUICRQ_ALPN "quicr-h25"
 #define QUICRQ_PORT 853
 
 /* QUICR error codes */

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -136,9 +136,6 @@ typedef struct st_quicrq_media_object_source_ctx_t quicrq_media_object_source_ct
 
 quicrq_media_object_source_ctx_t* quicrq_publish_object_source(quicrq_ctx_t* qr_ctx, const uint8_t* url, size_t url_length,
     quicrq_media_object_source_properties_t * properties);
-#if 0
-int quicrq_object_source_set_start(quicrq_media_object_source_ctx_t* object_source_ctx, uint64_t start_group_id, uint64_t start_object_id);
-#endif
 
 int quicrq_publish_object(
     quicrq_media_object_source_ctx_t* object_source_ctx,

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -124,7 +124,8 @@ typedef struct st_quicrq_media_object_header_t {
 
 typedef struct st_quicrq_media_object_source_properties_t {
     unsigned int use_real_time_caching : 1;
-    int tbd;
+    uint64_t start_group_id;
+    uint64_t start_object_id;
 } quicrq_media_object_source_properties_t;
 
 typedef struct st_quicrq_media_object_properties_t {
@@ -135,7 +136,9 @@ typedef struct st_quicrq_media_object_source_ctx_t quicrq_media_object_source_ct
 
 quicrq_media_object_source_ctx_t* quicrq_publish_object_source(quicrq_ctx_t* qr_ctx, const uint8_t* url, size_t url_length,
     quicrq_media_object_source_properties_t * properties);
+#if 0
 int quicrq_object_source_set_start(quicrq_media_object_source_ctx_t* object_source_ctx, uint64_t start_group_id, uint64_t start_object_id);
+#endif
 
 int quicrq_publish_object(
     quicrq_media_object_source_ctx_t* object_source_ctx,

--- a/lib/object_source.c
+++ b/lib/object_source.c
@@ -69,37 +69,6 @@ quicrq_media_object_source_ctx_t* quicrq_publish_object_source(quicrq_ctx_t* qr_
     }
     return(object_source_ctx);
 }
-#if 0
-int quicrq_object_source_set_start(quicrq_media_object_source_ctx_t* object_source_ctx, uint64_t start_group_id, uint64_t start_object_id)
-{
-    int ret = 0;
-    ret = quicrq_fragment_cache_learn_start_point(object_source_ctx->cache_ctx, start_group_id, start_object_id);
-    if (ret == 0) {
-        if (object_source_ctx->next_group_id < start_group_id ||
-            (object_source_ctx->next_group_id == start_group_id &&
-                object_source_ctx->next_object_id < start_object_id)) {
-            object_source_ctx->next_group_id = start_group_id;
-            object_source_ctx->next_object_id = start_object_id;
-        }
-    }
-    return ret;
-}
-
-static int quicrq_object_source_check_start(quicrq_media_object_source_ctx_t* object_source_ctx, uint64_t start_group_id, uint64_t start_object_id)
-{
-    int ret = 0;
-    if (object_source_ctx->next_group_id != 0 ||
-        object_source_ctx->next_object_id != 0) {
-        /* start point was already set */
-        ret = -1;
-    }
-    else {
-        ret = quicrq_object_source_set_start(object_source_ctx, start_group_id, start_object_id);
-    }
-
-    return ret;
-}
-#endif
 
 int quicrq_publish_object(
     quicrq_media_object_source_ctx_t* object_source_ctx,

--- a/lib/proto.c
+++ b/lib/proto.c
@@ -419,37 +419,49 @@ const uint8_t* quicrq_cache_policy_msg_decode(const uint8_t* bytes, const uint8_
  *     url(...)
  *     datagram_capable(i)
  *     cache_policy(8)
+ *     start_group_id(i)
+ *     start_object_id(i)
  *     
  * The post message is sent by a client when ready to push a media fragment.
  */
 
 size_t quicrq_post_msg_reserve(size_t url_length)
 {
-    return  1 + 2 + url_length + 1 + 1;
+    return  1 + 2 + url_length + 1 + 1 + 8 + 8;
 }
 
-uint8_t* quicrq_post_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length, const uint8_t* url, unsigned int datagram_capable, uint8_t cache_policy)
+uint8_t* quicrq_post_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length,
+    const uint8_t* url, unsigned int datagram_capable, uint8_t cache_policy,
+    uint64_t start_group_id, uint64_t start_object_id)
 {
     if ((bytes = picoquic_frames_varint_encode(bytes, bytes_max, message_type)) != NULL &&
         (bytes = picoquic_frames_length_data_encode(bytes, bytes_max, url_length, url)) != NULL &&
-        (bytes = picoquic_frames_varint_encode(bytes, bytes_max, datagram_capable)) != NULL) {
-        bytes = picoquic_frames_uint8_encode(bytes, bytes_max, cache_policy);
+        (bytes = picoquic_frames_varint_encode(bytes, bytes_max, datagram_capable)) != NULL &&
+        (bytes = picoquic_frames_uint8_encode(bytes, bytes_max, cache_policy)) != NULL &&
+        (bytes = picoquic_frames_varint_encode(bytes, bytes_max, start_group_id)) != NULL){
+        bytes = picoquic_frames_varint_encode(bytes, bytes_max, start_object_id);
     }
     return bytes;
 }
 
-const uint8_t* quicrq_post_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, size_t* url_length, const uint8_t** url, unsigned int* datagram_capable, uint8_t * cache_policy)
+const uint8_t* quicrq_post_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, 
+    size_t* url_length, const uint8_t** url, unsigned int* datagram_capable, uint8_t * cache_policy,
+    uint64_t* start_group_id, uint64_t* start_object_id)
 {
     uint64_t dg_cap = 0;
     *datagram_capable = 0;
     *url = NULL;
     *url_length = 0;
+    *start_group_id = 0;
+    *start_object_id = 0;
     if ((bytes = picoquic_frames_varint_decode(bytes, bytes_max, message_type)) != NULL &&
         (bytes = picoquic_frames_varlen_decode(bytes, bytes_max, url_length)) != NULL) {
         *url = bytes;
         if ((bytes = picoquic_frames_fixed_skip(bytes, bytes_max, *url_length)) != NULL &&
             (bytes = picoquic_frames_varint_decode(bytes, bytes_max, &dg_cap)) != NULL &&
-            (bytes = picoquic_frames_uint8_decode(bytes, bytes_max, cache_policy)) != NULL) {
+            (bytes = picoquic_frames_uint8_decode(bytes, bytes_max, cache_policy)) != NULL &&
+            (bytes = picoquic_frames_varint_decode(bytes, bytes_max, start_group_id)) != NULL  &&
+            (bytes = picoquic_frames_varint_decode(bytes, bytes_max, start_object_id)) != NULL) {
             if (dg_cap <= 3) {
                 *datagram_capable = (unsigned int)dg_cap;
             }
@@ -540,7 +552,8 @@ const uint8_t* quicrq_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max,
                 &msg->offset, &msg->is_last_fragment, &msg->flags, &msg->length, &msg->data);
             break;
         case QUICRQ_ACTION_POST:
-            bytes = quicrq_post_msg_decode(bytes, bytes_max, &msg->message_type, &msg->url_length, &msg->url, &msg->use_datagram, &msg->cache_policy);
+            bytes = quicrq_post_msg_decode(bytes, bytes_max, &msg->message_type, &msg->url_length, &msg->url,
+                &msg->use_datagram, &msg->cache_policy, &msg->group_id, &msg->object_id);
             break;
         case QUICRQ_ACTION_ACCEPT:
             bytes = quicrq_accept_msg_decode(bytes, bytes_max, &msg->message_type, &msg->use_datagram, &msg->datagram_stream_id);
@@ -587,7 +600,8 @@ uint8_t* quicrq_msg_encode(uint8_t* bytes, uint8_t* bytes_max, quicrq_message_t*
             msg->offset, msg->is_last_fragment, msg->flags, msg->length, msg->data);
         break;
     case QUICRQ_ACTION_POST:
-        bytes = quicrq_post_msg_encode(bytes, bytes_max, msg->message_type, msg->url_length, msg->url, msg->use_datagram, msg->cache_policy);
+        bytes = quicrq_post_msg_encode(bytes, bytes_max, msg->message_type, msg->url_length, msg->url,
+            msg->use_datagram, msg->cache_policy, msg->group_id, msg->object_id);
         break;
     case QUICRQ_ACTION_ACCEPT:
         bytes = quicrq_accept_msg_encode(bytes, bytes_max, msg->message_type, msg->use_datagram, msg->datagram_stream_id);
@@ -996,7 +1010,8 @@ int quicrq_cnx_post_media(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t 
             if (ret == 0) {
                 /* Format the post message */
                 uint8_t* message_next = quicrq_post_msg_encode(message->buffer, message->buffer + message->buffer_alloc,
-                    QUICRQ_ACTION_POST, url_length, url, (use_datagrams)?1:0, stream_ctx->is_cache_real_time);
+                    QUICRQ_ACTION_POST, url_length, url, (use_datagrams)?1:0, stream_ctx->is_cache_real_time,
+                    stream_ctx->start_group_id, stream_ctx->start_object_id);
                 if (message_next == NULL) {
                     ret = -1;
                 }

--- a/lib/quicrq.c
+++ b/lib/quicrq.c
@@ -1218,7 +1218,7 @@ int quicrq_prepare_to_send_on_stream(quicrq_stream_ctx_t* stream_ctx, void* cont
         quicrq_message_buffer_t* message = &stream_ctx->message_sent;
         /* Ready to send next message */
         if (stream_ctx->is_sender) {
-            if (stream_ctx->start_object_id > 0 && !stream_ctx->is_start_object_id_sent) {
+            if ((stream_ctx->start_group_id > 0 || stream_ctx->start_object_id > 0) && !stream_ctx->is_start_object_id_sent) {
                 ret = quicrq_prepare_start_point(stream_ctx);
             }
             else if ((stream_ctx->final_group_id > 0 || stream_ctx->final_object_id > 0) &&
@@ -1621,7 +1621,8 @@ int quicrq_receive_stream_data(quicrq_stream_ctx_t* stream_ctx, uint8_t* bytes, 
                                 (incoming.use_datagram) ? "datagram" : "stream");
                             /* Decide whether to receive the data as stream or as datagrams */
                             /* Prepare a consumer for the data. */
-                            ret = quicrq_cnx_accept_media(stream_ctx, incoming.url, incoming.url_length, incoming.use_datagram, incoming.cache_policy);
+                            ret = quicrq_cnx_accept_media(stream_ctx, incoming.url, incoming.url_length, incoming.use_datagram,
+                                incoming.cache_policy, incoming.group_id, incoming.object_id);
                         }
                         break;
                     case QUICRQ_ACTION_ACCEPT:

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -548,7 +548,7 @@ uint8_t* quicr_encode_object_header(uint8_t* fh, const uint8_t* fh_max, const qu
 
 /* Process a receive POST command */
 int quicrq_cnx_accept_media(quicrq_stream_ctx_t* stream_ctx, const uint8_t* url, size_t url_length,
-    int use_datagrams, uint8_t cache_policy);
+    int use_datagrams, uint8_t cache_policy, uint64_t start_group_id, uint64_t start_object_id);
 
 /*  Process a received ACCEPT response */
 int quicrq_cnx_post_accepted(quicrq_stream_ctx_t* stream_ctx, unsigned int use_datagrams, uint64_t datagram_stream_id);

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -126,8 +126,12 @@ uint8_t* quicrq_rq_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t messa
 const uint8_t* quicrq_rq_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, size_t* url_length, const uint8_t** url,
     quicrq_subscribe_intent_enum * intent_mode, uint64_t * start_group_id,  uint64_t * start_object_id, uint64_t* datagram_stream_id);
 size_t quicrq_post_msg_reserve(size_t url_length);
-uint8_t* quicrq_post_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length, const uint8_t* url, unsigned int datagram_capable, uint8_t cache_policy);
-const uint8_t* quicrq_post_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type, size_t* url_length, const uint8_t** url, unsigned int* datagram_capable, uint8_t* cache_policy);
+uint8_t* quicrq_post_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, size_t url_length, 
+    const uint8_t* url, unsigned int datagram_capable, uint8_t cache_policy,
+    uint64_t start_group_id, uint64_t start_object_id);
+const uint8_t* quicrq_post_msg_decode(const uint8_t* bytes, const uint8_t* bytes_max, uint64_t* message_type,
+    size_t* url_length, const uint8_t** url, unsigned int* datagram_capable, uint8_t* cache_policy,
+    uint64_t* start_group_id, uint64_t* start_object_id);
 size_t quicrq_fin_msg_reserve(uint64_t final_group_id, uint64_t final_object_id);
 uint8_t* quicrq_fin_msg_encode(uint8_t* bytes, uint8_t* bytes_max, uint64_t message_type, 
     uint64_t final_group_id, uint64_t final_object_id);

--- a/tests/proto_test.c
+++ b/tests/proto_test.c
@@ -236,8 +236,8 @@ static quicrq_message_t post_msg = {
     sizeof(url1),
     url1,
     0,
-    0,
-    0,
+    1,
+    12,
     0,
     0,
     0,
@@ -254,7 +254,9 @@ static uint8_t post_msg_bytes[] = {
     sizeof(url1),
     URL1_BYTES,
     3,
-    1
+    1,
+    1,
+    12
 };
 
 static quicrq_message_t accept_dg = {
@@ -505,7 +507,9 @@ static uint8_t bad_bytes11[] = {
     0x4F,
     0xFF,
     URL1_BYTES,
-    17
+    17,
+    1,
+    12
 };
 
 static uint8_t bad_bytes12[] = {

--- a/tests/quicrq_test_internal.h
+++ b/tests/quicrq_test_internal.h
@@ -184,8 +184,6 @@ test_media_object_source_context_t* test_media_object_source_publish(quicrq_ctx_
 test_media_object_source_context_t* test_media_object_source_publish_ex(quicrq_ctx_t* qr_ctx, uint8_t* url, size_t url_length,
     char const* media_source_path, const generation_parameters_t* generation_model, int is_real_time,
     uint64_t start_time, quicrq_media_object_source_properties_t* properties);
-int test_media_object_source_set_start(test_media_object_source_context_t* object_pub_ctx, uint64_t start_group, uint64_t start_object);
-
 int test_media_derive_file_names(const uint8_t* url, size_t url_length, int is_datagram, int is_real_time, int is_post,
     char* result_file_name, char* result_log_name, size_t result_name_size);
 

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -611,17 +611,22 @@ int test_media_object_source_set_start(test_media_object_source_context_t* objec
         }
         else {
             /* Read the media file until the context matches */
-            while (ret == 0 && (group_id < start_group || (group_id == start_group && object_id + 1 < start_object))) {
+            while (ret == 0 && (group_id < start_group || (group_id == start_group && object_id < start_object))) {
                 ret = test_media_read_object_from_file(object_pub_ctx->pub_ctx);
                 if (object_id > 0 && test_media_is_new_group(object_pub_ctx->pub_ctx->current_header.length)) {
                     group_id++;
                     object_id = 0;
-                } else {
+                }
+                else {
                     object_id++;
                 }
             }
-            /* set the start point */
-            ret = quicrq_object_source_set_start(object_pub_ctx->object_source_ctx, start_group, start_object);
+            if (ret == 0) {
+                /* mark the segment as available */
+                object_pub_ctx->object_is_ready = 1;
+                /* set the start point */
+                ret = quicrq_object_source_set_start(object_pub_ctx->object_source_ctx, start_group, start_object);
+            }
         }
     }
     else {

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -134,9 +134,9 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
             ret = -1;
         }
         else if (start_point != 0) {
-            ret = test_media_object_source_set_start(config->object_sources[0], 1, 1);
+            ret = test_media_object_source_set_start(config->object_sources[0], 1, 0);
             start_group_intent = 1;
-            start_object_intent = 1;
+            start_object_intent = 0;
         }
     }
 
@@ -206,7 +206,7 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
                 break;
             case quicrq_subscribe_intent_start_point:
                 intent.start_group_id = 1;
-                intent.start_object_id = 2;
+                intent.start_object_id = 0;
                 start_group_intent =  intent.start_group_id;
                 start_object_intent = intent.start_object_id;
                 break;

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -128,15 +128,17 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
             quicrq_set_cache_duration(config->nodes[0], 5000000);
         }
 
+        if (start_point != 0) {
+            properties.start_group_id = 1;
+            properties.start_object_id = 0;
+            start_group_intent = 1;
+            start_object_intent = 0;
+        }
+
         config->object_sources[0] = test_media_object_source_publish_ex(config->nodes[publish_node], (uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
             strlen(QUICRQ_TEST_BASIC_SOURCE), media_source_path, NULL, is_real_time, config->simulated_time, &properties);
         if (config->object_sources[0] == NULL) {
             ret = -1;
-        }
-        else if (start_point != 0) {
-            ret = test_media_object_source_set_start(config->object_sources[0], 1, 0);
-            start_group_intent = 1;
-            start_object_intent = 0;
         }
     }
 


### PR DESCRIPTION
First part of merging the functionalities of Post, Publish Object Source and Set Start of object source in a single API.

The first step merges Publish Object Source and Set Start , and removes the old set start API.
The POST protocol message is augmented to carry the cache policy and start point set as properties during publish object source.