### PR TITLE
Don't send useless datagram fragments

### DIFF
--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -335,6 +335,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_intent_dg_nc) {
+			int ret = quicrq_triangle_intent_dg_nc_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(triangle_intent_loss) {
 			int ret = quicrq_triangle_intent_loss_test();
 

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -329,6 +329,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_intent_nc) {
+			int ret = quicrq_triangle_intent_nc_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(triangle_intent_datagram) {
 			int ret = quicrq_triangle_intent_datagram_test();
 

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -14,7 +14,7 @@ extern "C" {
  * The minor version is updated when the protocol changes
  * Only the letter is updated if the code changes without changing the protocol
  */
-#define QUICRQ_VERSION "0.25"
+#define QUICRQ_VERSION "0.25a"
 
 /* QUICR ALPN and QUICR port
  * For version zero, the ALPN is set to "quicr-h<minor>", where <minor> is

--- a/lib/fragment.c
+++ b/lib/fragment.c
@@ -750,12 +750,22 @@ int quicrq_fragment_datagram_publisher_check_fragment(
 {
     int ret = 0;
     quicrq_fragment_publisher_object_state_t* publisher_object = NULL;
-
+#if 1
+    if (stream_ctx->cnx_ctx->is_server) {
+        DBG_PRINTF("%s", "bug");
+    }
+#endif
     *should_skip = 0;
 
     /* The "current fragment" shall never be NULL, unless this is the very first one. */
     if (media_ctx->current_fragment == NULL) {
         media_ctx->current_fragment = media_ctx->cache_ctx->first_fragment;
+        while (media_ctx->current_fragment != NULL &&
+            (media_ctx->current_fragment->group_id < stream_ctx->start_group_id ||
+                (media_ctx->current_fragment->group_id == stream_ctx->start_group_id &&
+                    media_ctx->current_fragment->object_id < stream_ctx->start_object_id))) {
+            media_ctx->current_fragment = media_ctx->current_fragment->next_in_order;
+        }
         media_ctx->is_current_fragment_sent = 0;
     }
     if (media_ctx->current_fragment == NULL) {
@@ -786,7 +796,10 @@ int quicrq_fragment_datagram_publisher_check_fragment(
                     break;
                 }
             }
-            else if (publisher_object->is_dropped){
+            else if (publisher_object->is_dropped ||
+                (media_ctx->current_fragment->group_id < stream_ctx->start_group_id ||
+                (media_ctx->current_fragment->group_id == stream_ctx->start_group_id &&
+                    media_ctx->current_fragment->object_id < stream_ctx->start_object_id))){
                 /* Continue looking for the next object */
                 media_ctx->is_current_fragment_sent = 1;
             }

--- a/lib/fragment.c
+++ b/lib/fragment.c
@@ -750,11 +750,6 @@ int quicrq_fragment_datagram_publisher_check_fragment(
 {
     int ret = 0;
     quicrq_fragment_publisher_object_state_t* publisher_object = NULL;
-#if 1
-    if (stream_ctx->cnx_ctx->is_server) {
-        DBG_PRINTF("%s", "bug");
-    }
-#endif
     *should_skip = 0;
 
     /* The "current fragment" shall never be NULL, unless this is the very first one. */

--- a/lib/quicrq.c
+++ b/lib/quicrq.c
@@ -507,6 +507,7 @@ int quicrq_receive_datagram(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* bytes, siz
             }
         }
         else {
+            /* Verification that there are no unexpected fragments, used in tests */
             if (group_id < stream_ctx->start_group_id ||
                 (group_id == stream_ctx->start_group_id && object_id < stream_ctx->start_object_id)) {
                 cnx_ctx->qr_ctx->useless_fragments += 1;
@@ -1681,6 +1682,12 @@ int quicrq_receive_stream_data(quicrq_stream_ctx_t* stream_ctx, uint8_t* bytes, 
                             ret = -1;
                         }
                         else {
+                            /* Verification that there are no unexpected fragments, used in tests */
+                            if (incoming.group_id < stream_ctx->start_group_id ||
+                                (incoming.group_id == stream_ctx->start_group_id &&
+                                    incoming.object_id < stream_ctx->start_object_id)) {
+                                stream_ctx->cnx_ctx->qr_ctx->useless_fragments++;
+                            }
                             /* Pass the repair data to the media consumer. */
                             ret = stream_ctx->consumer_fn(quicrq_media_datagram_ready, stream_ctx->media_ctx, picoquic_get_quic_time(stream_ctx->cnx_ctx->qr_ctx->quic),
                                 incoming.data, incoming.group_id, incoming.object_id,
@@ -1832,22 +1839,13 @@ int quicrq_callback(picoquic_cnx_t* cnx,
             }
             break;
         case picoquic_callback_datagram:
-#if 1
-            if (!cnx_ctx->is_server) {
-                DBG_PRINTF("%s", "bug");
-            }
-#endif
             /* Receive data in a datagram */
             ret = quicrq_receive_datagram(cnx_ctx, bytes, length, picoquic_get_quic_time(cnx_ctx->qr_ctx->quic));
             break;
         case picoquic_callback_prepare_datagram:
             /* Prepare to send a datagram */ {
             uint64_t current_time = picoquic_get_quic_time(cnx_ctx->qr_ctx->quic);
-#if 1
-            if (cnx_ctx->is_server && current_time > 4000000) {
-                DBG_PRINTF("%s", "Bug");
-            }
-#endif
+
             ret = quicrq_prepare_to_send_datagram(cnx_ctx, bytes, length, current_time);
             break;
         }

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -529,6 +529,8 @@ struct st_quicrq_ctx_t {
     int extra_repeat_on_nack : 1;
     int extra_repeat_after_received_delayed : 1;
     uint64_t extra_repeat_delay;
+    /* Count of media fragments received with numbers < start point */
+    uint64_t useless_fragments;
     /* Control whether to enable congestion control -- mostly for testability */
     unsigned int do_congestion_control : 1;
 };

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -73,6 +73,7 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_cache_loss", quicrq_triangle_cache_loss_test },
     { "triangle_cache_stream", quicrq_triangle_cache_stream_test },
     { "triangle_intent", quicrq_triangle_intent_test },
+    { "triangle_intent_nc", quicrq_triangle_intent_nc_test },
     { "triangle_intent_datagram", quicrq_triangle_intent_datagram_test },
     { "triangle_intent_dg_nc", quicrq_triangle_intent_dg_nc_test },
     { "triangle_intent_loss", quicrq_triangle_intent_loss_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -74,6 +74,7 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_cache_stream", quicrq_triangle_cache_stream_test },
     { "triangle_intent", quicrq_triangle_intent_test },
     { "triangle_intent_datagram", quicrq_triangle_intent_datagram_test },
+    { "triangle_intent_dg_nc", quicrq_triangle_intent_dg_nc_test },
     { "triangle_intent_loss", quicrq_triangle_intent_loss_test },
     { "triangle_intent_next", quicrq_triangle_intent_next_test },
     { "triangle_intent_next_s", quicrq_triangle_intent_next_s_test },

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -58,6 +58,7 @@ extern "C" {
     int quicrq_triangle_cache_loss_test();
     int quicrq_triangle_cache_stream_test();
     int quicrq_triangle_intent_test();
+    int quicrq_triangle_intent_nc_test();
     int quicrq_triangle_intent_datagram_test();
     int quicrq_triangle_intent_dg_nc_test();
     int quicrq_triangle_intent_loss_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -59,6 +59,7 @@ extern "C" {
     int quicrq_triangle_cache_stream_test();
     int quicrq_triangle_intent_test();
     int quicrq_triangle_intent_datagram_test();
+    int quicrq_triangle_intent_dg_nc_test();
     int quicrq_triangle_intent_loss_test();
     int quicrq_triangle_intent_next_test();
     int quicrq_triangle_intent_next_s_test();

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -122,8 +122,11 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
         /* Add a test source to the configuration on client #1 (publisher) */
         quicrq_media_object_source_properties_t properties = { 0 };
         int publish_node = 1;
-
+#if 1
+        if (test_cache_clear) {
+#else
         if (test_cache_clear || test_intent > 0) {
+#endif
             properties.use_real_time_caching = 1;
             quicrq_set_cache_duration(config->nodes[0], 5000000);
         }
@@ -322,6 +325,15 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
         }
     }
 
+    if (ret == 0) {
+        for (int i = 0; i < config->nb_nodes; i++) {
+            if (config->nodes[i]->useless_fragments > 0) {
+                DBG_PRINTF("Received %" PRIu64 " useless fragments at node %i", config->nodes[i]->useless_fragments);
+                ret = -1;
+            }
+        }
+    }
+
     /* Clear everything. */
     if (config != NULL) {
         quicrq_test_config_delete(config);
@@ -424,6 +436,13 @@ int quicrq_triangle_intent_test()
 int quicrq_triangle_intent_datagram_test()
 {
     int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 1, 1);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_dg_nc_test()
+{
+    int ret = quicrq_triangle_test_one(1, 1, 0, 0, 0, 0, 1);
 
     return ret;
 }

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -122,11 +122,8 @@ int quicrq_triangle_test_one(int is_real_time, int use_datagrams, uint64_t simul
         /* Add a test source to the configuration on client #1 (publisher) */
         quicrq_media_object_source_properties_t properties = { 0 };
         int publish_node = 1;
-#if 1
+
         if (test_cache_clear) {
-#else
-        if (test_cache_clear || test_intent > 0) {
-#endif
             properties.use_real_time_caching = 1;
             quicrq_set_cache_duration(config->nodes[0], 5000000);
         }
@@ -429,6 +426,13 @@ int quicrq_triangle_cache_stream_test()
 int quicrq_triangle_intent_test()
 {
     int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 1, 1);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_nc_test()
+{
+    int ret = quicrq_triangle_test_one(1, 0, 0, 0, 0, 0, 1);
 
     return ret;
 }


### PR DESCRIPTION
There was a report of relays sending lots of unexpected data after "subscribe intent". Reproduce the issue with tests, and fix it.

Still a work in progress: need to verify that the issue is also fixed for datagrams.