### PR TITLE
Warp congestion

### DIFF
--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -552,6 +552,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(warp_triangle) {
+			int ret = quicrq_triangle_warp_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(warp_congestion) {
 			int ret = quicrq_congestion_warp_test();
 

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -552,6 +552,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(warp_congestion) {
+			int ret = quicrq_congestion_warp_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(warp_relay) {
 			int ret = quicrq_warp_relay_test();
 

--- a/lib/reassembly.c
+++ b/lib/reassembly.c
@@ -521,7 +521,10 @@ int quicrq_reassembly_learn_final_object_id(
         ret = -1;
     }
 
-    if (ret == 0 && reassembly_ctx->next_object_id >= final_object_id) {
+    if (ret == 0 && (
+        reassembly_ctx->next_group_id > final_group_id || (
+            reassembly_ctx->next_group_id == final_group_id &&
+            reassembly_ctx->next_object_id >= final_object_id))) {
         reassembly_ctx->is_finished = 1;
     }
 

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -109,6 +109,7 @@ static const quicrq_test_def_t test_table[] =
     { "get_addr", quicrq_get_addr_test },
     { "warp_basic", quicrq_warp_basic_test },
     { "warp_basic_client", quicrq_warp_basic_client_test },
+    { "warp_congestion", quicrq_congestion_warp_test },
     { "warp_relay", quicrq_warp_relay_test },
     { "warp_basic_loss", quicrq_warp_basic_loss_test },
     { "warp_relay_loss", quicrq_warp_relay_loss_test }

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -109,6 +109,7 @@ static const quicrq_test_def_t test_table[] =
     { "get_addr", quicrq_get_addr_test },
     { "warp_basic", quicrq_warp_basic_test },
     { "warp_basic_client", quicrq_warp_basic_client_test },
+    { "warp_triangle", quicrq_triangle_warp_test },
     { "warp_congestion", quicrq_congestion_warp_test },
     { "warp_relay", quicrq_warp_relay_test },
     { "warp_basic_loss", quicrq_warp_basic_loss_test },

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -554,3 +554,20 @@ int quicrq_congestion_datagram_zero_test()
 
     return ret;
 }
+
+int quicrq_congestion_warp_test()
+{
+    quicrq_congestion_test_t spec = { 0 };
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 73;
+    spec.min_loss_flag = 0x82;
+    spec.average_delay_target = 210000;
+    spec.max_delay_target = 700000;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_warp, &spec);
+
+    return ret;
+}

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -94,6 +94,7 @@ extern "C" {
     int quicrq_get_addr_test();
     int quicrq_warp_basic_test();
     int quicrq_warp_basic_client_test();
+    int quicrq_congestion_warp_test();
     int quicrq_warp_relay_test();
     int quicrq_warp_basic_loss_test();
     int quicrq_warp_relay_loss_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -94,6 +94,7 @@ extern "C" {
     int quicrq_get_addr_test();
     int quicrq_warp_basic_test();
     int quicrq_warp_basic_client_test();
+    int quicrq_triangle_warp_test();
     int quicrq_congestion_warp_test();
     int quicrq_warp_relay_test();
     int quicrq_warp_basic_loss_test();

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -382,6 +382,13 @@ int quicrq_triangle_datagram_extra_test()
     return ret;
 }
 
+int quicrq_triangle_warp_test()
+{
+    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_warp, 0, 0, 0, 0, 0);
+
+    return ret;
+}
+
 /* The start point test verifies what happens if a source does not start
  * at Group=0, Object=0. That would be, for example, a source resuming
  * after a hiatus. This test will have to be rewritten after we change


### PR DESCRIPTION
Testing first that congestion control as currently implemented also works in warp mode. Then, will test whether we can implement "warp like" congestion, i.e., only drop frames if next block is available.