### PR TITLE
GOP-based congestion control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ message(STATUS "OpenSSL_LIBRARIES: ${OPENSSL_LIBRARIES}")
 
 
 add_library(quicrq-core
+    lib/congestion.c
     lib/fragment.c
     lib/quicrq.c
     lib/proto.c

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -108,6 +108,13 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(congestion_datagram_g)
+		{
+			int ret = quicrq_congestion_datagram_g_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(media_video1)
 		{
 			int ret = quicrq_media_video1_test();

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -59,6 +59,13 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(congestion_basic_g)
+		{
+			int ret = quicrq_congestion_basic_g_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(congestion_datagram)
 		{
 			int ret = quicrq_congestion_datagram_test();
@@ -560,6 +567,12 @@ namespace UnitTest
 
 		TEST_METHOD(warp_congestion) {
 			int ret = quicrq_congestion_warp_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(warp_congestion_g) {
+			int ret = quicrq_congestion_warp_g_test();
 
 			Assert::AreEqual(ret, 0);
 		}

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -317,7 +317,7 @@ uint64_t quicrq_handle_extra_repeat(quicrq_ctx_t* qr, uint64_t current_time);
  */
 
 typedef enum {
-    quicrq_congestion_control_node = 0,
+    quicrq_congestion_control_none = 0,
     quicrq_congestion_control_delay = 1,
     quicrq_congestion_control_group = 2,
     quicrq_congestion_control_max

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -313,9 +313,17 @@ void quicrq_set_extra_repeat_delay(quicrq_ctx_t* qr, uint64_t delay_in_microseco
 uint64_t quicrq_handle_extra_repeat(quicrq_ctx_t* qr, uint64_t current_time);
 
 /* Enable of disable congestion control.
- * Default to disable.
+ * Default to "none", i.e., disable.
  */
-void quicrq_enable_congestion_control(quicrq_ctx_t* qr, int enable_congestion_control);
+
+typedef enum {
+    quicrq_congestion_control_node = 0,
+    quicrq_congestion_control_delay = 1,
+    quicrq_congestion_control_group = 2,
+    quicrq_congestion_control_max
+} quicrq_congestion_control_enum;
+
+void quicrq_enable_congestion_control(quicrq_ctx_t* qr, quicrq_congestion_control_enum congestion_control_mode);
 
 #ifdef __cplusplus
 }

--- a/lib/congestion.c
+++ b/lib/congestion.c
@@ -1,0 +1,186 @@
+/* Handling of the congestion control algorithms */
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+#include "picoquic_utils.h"
+#include "picosplay.h"
+#include "quicrq.h"
+#include "quicrq_reassembly.h"
+#include "quicrq_internal.h"
+#include "quicrq_fragment.h"
+
+
+/* Handle congestion. This should be done per connection, at least once per RTT.
+* Check whether there is congestion, and also check the highest (least urgent)
+* priority level among the streams.
+* 
+* There are two marks and a priority level
+* - has_backlog:
+*    set if one stream reports backlog.
+*    cleared at beginning of congestion epoch.
+* - is_congested:
+*    set initially when the first backlog is reported.
+*    cleared when not congested anymore
+* - priority_threshold
+*    packets at this or higher threshold are skipped.
+* 
+* The state also includes the "start of epoch" time, and the "old priority
+* threshold
+*    
+* 
+* The marks are evaluated:
+* - when the first congestion is reported (has_backlog && !is_congested)
+*     - this starts an epoch.
+* - at the beginning of every new epoch.
+*     - if this is the first epoch for this priority, do nothing
+*       because the priority had no observable effect.
+*     - if backlog reported, and threshold > 128, decrease threshold
+*     - else if no backlog reported during the last epoch, increase the threshold
+*         - if threshold larger than max flag, clear "is_congested".
+* - in any case, reset "has_backlog", "old threshold", and epoch time.
+*  
+*/
+int quicrq_congestion_check_per_cnx(quicrq_cnx_ctx_t* cnx_ctx, uint8_t flags, int has_backlog, uint64_t current_time)
+{
+    int should_skip = 0;
+
+    /* Update the 'worst flag for the connection' */
+    if (flags > cnx_ctx->congestion.max_flags && flags != 0xff) {
+        cnx_ctx->congestion.max_flags = flags;
+    }
+    cnx_ctx->congestion.has_backlog |= has_backlog;
+
+    if (!cnx_ctx->congestion.is_congested) {
+        if (has_backlog) {
+            /* Enter the congested state */
+            cnx_ctx->congestion.is_congested = 1;
+            cnx_ctx->congestion.has_backlog = 0;
+            cnx_ctx->congestion.priority_threshold = cnx_ctx->congestion.max_flags;
+            cnx_ctx->congestion.old_priority_threshold = 0xff;
+        }
+    } else if (current_time >= cnx_ctx->congestion.congestion_check_time) {
+        /* Check the epoch */
+        uint8_t old_priority_threshold = cnx_ctx->congestion.priority_threshold;
+
+        if (cnx_ctx->congestion.old_priority_threshold != cnx_ctx->congestion.priority_threshold) {
+            /* The threshold was changed at the last epoch check, so
+            * congestion would not reflect the next threshold. Do nothing. */
+        } else if (cnx_ctx->congestion.has_backlog) {
+            /* if congested, set threshold priority to lower value */
+            if (cnx_ctx->congestion.priority_threshold > 0x80) {
+                cnx_ctx->congestion.priority_threshold -= 1;
+            }
+        }
+        else {
+            if (cnx_ctx->congestion.priority_threshold < cnx_ctx->congestion.max_flags) {
+                cnx_ctx->congestion.priority_threshold += 1;
+            }
+            else {
+                cnx_ctx->congestion.is_congested = 0;
+            }
+        }
+        /* Reset the values to prepare the next epoch */
+        cnx_ctx->congestion.old_priority_threshold = old_priority_threshold;
+        cnx_ctx->congestion.has_backlog = 0;
+        cnx_ctx->congestion.congestion_check_time += 50000; /* TODO: should be RTT of connection */
+    }
+    /* Evaluate whether this packet should be skipped */
+    if (cnx_ctx->qr_ctx->congestion_control_mode != 0 && cnx_ctx->congestion.is_congested && flags >= cnx_ctx->congestion.priority_threshold) {
+        should_skip = 1;
+    }
+    return should_skip;
+}
+
+int quicrq_compute_group_mode_backlog(quicrq_fragment_cache_t* cache_ctx, uint64_t current_group_id, uint64_t current_object_id)
+{
+    int has_backlog = 0;
+
+    if (current_group_id < cache_ctx->next_group_id) {
+        if (current_group_id + 1 == cache_ctx->next_group_id) {
+
+        }
+    }
+    return has_backlog;
+}
+
+/* Evaluation of backlog for single stream transmission
+ */
+int quicrq_fragment_evaluate_backlog(quicrq_fragment_publisher_context_t* media_ctx)
+{
+    int has_backlog = 0;
+    const uint64_t backlog_threshold = 5;
+
+    if (media_ctx->current_offset > 0 || media_ctx->length_sent > 0) {
+        has_backlog = media_ctx->has_backlog;
+    }
+    else {
+        switch (media_ctx->congestion_control_mode) {
+        case quicrq_congestion_control_none:
+            break;
+        case quicrq_congestion_control_group:
+            /* TODO: compute group mode congestion control */
+            break;
+        case quicrq_congestion_control_delay:
+        default:
+            if (media_ctx->current_group_id < media_ctx->cache_ctx->next_group_id ||
+                (media_ctx->current_group_id == media_ctx->cache_ctx->next_group_id &&
+                    media_ctx->current_object_id + backlog_threshold < media_ctx->cache_ctx->next_object_id)) {
+                has_backlog = 1;
+                media_ctx->has_backlog = 1;
+            }
+            else {
+                has_backlog = 0;
+                media_ctx->has_backlog = 0;
+            }
+            break;
+        }
+    }
+    return has_backlog;
+}
+
+/* Checking congestion in warp mode */
+int quicrq_evaluate_warp_backlog(quicrq_uni_stream_ctx_t* uni_stream_ctx, quicrq_fragment_publisher_context_t* media_ctx)
+{
+    int has_backlog = 0;
+    const uint64_t backlog_threshold = 5;
+    quicrq_fragment_cache_t* cache_ctx = media_ctx->cache_ctx;
+
+    switch (media_ctx->congestion_control_mode) {
+    case quicrq_congestion_control_none:
+        break;
+    case quicrq_congestion_control_group:
+        /* TODO: compute group mode congestion control */
+        break;
+    case quicrq_congestion_control_delay:
+    default:
+        if (uni_stream_ctx->current_group_id < cache_ctx->next_group_id ||
+            (uni_stream_ctx->current_group_id == cache_ctx->next_group_id &&
+                uni_stream_ctx->current_object_id + backlog_threshold < cache_ctx->next_object_id)) {
+            has_backlog = 1;
+        }
+        break;
+    }
+
+    return has_backlog;
+}
+
+/* Backlog evaluation in datagram mode */
+int quicrq_evaluate_datagram_backlog(quicrq_fragment_publisher_context_t* media_ctx, uint64_t current_time)
+{
+    const int64_t delta_t_max = 5 * 33333;
+    int has_backlog = 0;
+
+    switch (media_ctx->congestion_control_mode) {
+    case quicrq_congestion_control_none:
+        break;
+    case quicrq_congestion_control_group:
+        /* TODO: compute group mode congestion control */
+        break;
+    case quicrq_congestion_control_delay:
+    default:
+        has_backlog = (current_time - media_ctx->current_fragment->cache_time) > delta_t_max;
+        break;
+    }
+
+    return has_backlog;
+}

--- a/lib/quicrq.c
+++ b/lib/quicrq.c
@@ -111,7 +111,7 @@ int quicrq_congestion_check_per_cnx(quicrq_cnx_ctx_t* cnx_ctx, uint8_t flags, in
         cnx_ctx->congestion.congestion_check_time += 50000; /* TODO: should be RTT of connection */
     }
     /* Evaluate whether this packet should be skipped */
-    if (cnx_ctx->qr_ctx->do_congestion_control && cnx_ctx->congestion.is_congested && flags >= cnx_ctx->congestion.priority_threshold) {
+    if (cnx_ctx->qr_ctx->congestion_control_mode != 0 && cnx_ctx->congestion.is_congested && flags >= cnx_ctx->congestion.priority_threshold) {
         should_skip = 1;
     }
     return should_skip;
@@ -1132,9 +1132,13 @@ uint64_t quicrq_handle_extra_repeat(quicrq_ctx_t* qr, uint64_t current_time)
 
 /* Enable of disablecongestion control*/
 
-void quicrq_enable_congestion_control(quicrq_ctx_t* qr, int enable_congestion_control)
+void quicrq_enable_congestion_control(quicrq_ctx_t* qr, quicrq_congestion_control_enum congestion_control_mode)
 {
-    qr->do_congestion_control = (enable_congestion_control == 0) ? 0 : 1;
+    if (congestion_control_mode < 0 || congestion_control_mode >= quicrq_congestion_control_max)
+        qr->congestion_control_mode = quicrq_congestion_control_delay;
+    else {
+        qr->congestion_control_mode = (quicrq_congestion_control_enum)congestion_control_mode;
+    }
 }
 
 /* Prepare to send a datagram */

--- a/lib/quicrq.c
+++ b/lib/quicrq.c
@@ -36,87 +36,6 @@
 #include "quicrq_relay.h"
 #include "quicrq_fragment.h"
 
-/* Handle congestion. This should be done per connection, at least once per RTT.
- * Check whether there is congestion, and also check the highest (least urgent)
- * priority level among the streams.
- * 
- * There are two marks and a priority level
- * - has_backlog:
- *    set if one stream reports backlog.
- *    cleared at beginning of congestion epoch.
- * - is_congested:
- *    set initially when the first backlog is reported.
- *    cleared when not congested anymore
- * - priority_threshold
- *    packets at this or higher threshold are skipped.
- * 
- * The state also includes the "start of epoch" time, and the "old priority
- * threshold
- *    
- * 
- * The marks are evaluated:
- * - when the first congestion is reported (has_backlog && !is_congested)
- *     - this starts an epoch.
- * - at the beginning of every new epoch.
- *     - if this is the first epoch for this priority, do nothing
- *       because the priority had no observable effect.
- *     - if backlog reported, and threshold > 128, decrease threshold
- *     - else if no backlog reported during the last epoch, increase the threshold
- *         - if threshold larger than max flag, clear "is_congested".
- * - in any case, reset "has_backlog", "old threshold", and epoch time.
- *  
- */
-int quicrq_congestion_check_per_cnx(quicrq_cnx_ctx_t* cnx_ctx, uint8_t flags, int has_backlog, uint64_t current_time)
-{
-    int should_skip = 0;
-
-    /* Update the 'worst flag for the connection' */
-    if (flags > cnx_ctx->congestion.max_flags && flags != 0xff) {
-        cnx_ctx->congestion.max_flags = flags;
-    }
-    cnx_ctx->congestion.has_backlog |= has_backlog;
-
-    if (!cnx_ctx->congestion.is_congested) {
-        if (has_backlog) {
-            /* Enter the congested state */
-            cnx_ctx->congestion.is_congested = 1;
-            cnx_ctx->congestion.has_backlog = 0;
-            cnx_ctx->congestion.priority_threshold = cnx_ctx->congestion.max_flags;
-            cnx_ctx->congestion.old_priority_threshold = 0xff;
-        }
-    } else if (current_time >= cnx_ctx->congestion.congestion_check_time) {
-        /* Check the epoch */
-        uint8_t old_priority_threshold = cnx_ctx->congestion.priority_threshold;
-
-        if (cnx_ctx->congestion.old_priority_threshold != cnx_ctx->congestion.priority_threshold) {
-            /* The threshold was changed at the last epoch check, so
-             * congestion would not reflect the next threshold. Do nothing. */
-        } else if (cnx_ctx->congestion.has_backlog) {
-            /* if congested, set threshold priority to lower value */
-            if (cnx_ctx->congestion.priority_threshold > 0x80) {
-                cnx_ctx->congestion.priority_threshold -= 1;
-            }
-        }
-        else {
-            if (cnx_ctx->congestion.priority_threshold < cnx_ctx->congestion.max_flags) {
-                cnx_ctx->congestion.priority_threshold += 1;
-            }
-            else {
-                cnx_ctx->congestion.is_congested = 0;
-            }
-        }
-        /* Reset the values to prepare the next epoch */
-        cnx_ctx->congestion.old_priority_threshold = old_priority_threshold;
-        cnx_ctx->congestion.has_backlog = 0;
-        cnx_ctx->congestion.congestion_check_time += 50000; /* TODO: should be RTT of connection */
-    }
-    /* Evaluate whether this packet should be skipped */
-    if (cnx_ctx->qr_ctx->congestion_control_mode != 0 && cnx_ctx->congestion.is_congested && flags >= cnx_ctx->congestion.priority_threshold) {
-        should_skip = 1;
-    }
-    return should_skip;
-}
-
 /* Allocate space in the message buffer */
 int quicrq_msg_buffer_alloc(quicrq_message_buffer_t* msg_buffer, size_t space, size_t bytes_stored)
 {
@@ -1425,21 +1344,6 @@ int quicrq_prepare_to_send_on_stream(quicrq_stream_ctx_t* stream_ctx, void* cont
     return ret;
 }
 
-/* Checking congestion in warp mode */
-int quicrq_evaluate_warp_backlog(quicrq_uni_stream_ctx_t* uni_stream_ctx, quicrq_fragment_cache_t* cache_ctx)
-{
-    int has_backlog = 0;
-    const uint64_t backlog_threshold = 5;
-    
-    if (uni_stream_ctx->current_group_id < cache_ctx->next_group_id ||
-        (uni_stream_ctx->current_group_id == cache_ctx->next_group_id &&
-            uni_stream_ctx->current_object_id + backlog_threshold < cache_ctx->next_object_id)) {
-        has_backlog = 1;
-    }
-
-    return has_backlog;
-}
-
 /* Sending data on unidirectional stream, for warp mode */
 int quicrq_prepare_to_send_on_unistream(quicrq_cnx_ctx_t * cnx_ctx, quicrq_uni_stream_ctx_t * uni_stream_ctx, void* context, size_t space, uint64_t current_time)
 {
@@ -1524,7 +1428,7 @@ int quicrq_prepare_to_send_on_unistream(quicrq_cnx_ctx_t * cnx_ctx, quicrq_uni_s
                     }
                     else {
                         /* Check whether there is ongoing congestion */
-                        has_backlog = quicrq_evaluate_warp_backlog(uni_stream_ctx, cache_ctx);
+                        has_backlog = quicrq_evaluate_warp_backlog(uni_stream_ctx, media_ctx);
                         if (uni_stream_ctx->current_object_id > 0 && flags != 0xff) {
                             should_skip = quicrq_congestion_check_per_cnx(uni_stream_ctx->control_stream_ctx->cnx_ctx,
                                 flags, has_backlog, current_time);

--- a/lib/quicrq_fragment.h
+++ b/lib/quicrq_fragment.h
@@ -64,11 +64,13 @@ typedef struct st_quicrq_fragment_publisher_object_state_t {
 } quicrq_fragment_publisher_object_state_t;
 
 typedef struct st_quicrq_fragment_publisher_context_t {
+    quicrq_stream_ctx_t* stream_ctx;
     quicrq_fragment_cache_t* cache_ctx;
     uint64_t current_group_id;
     uint64_t current_object_id;
     size_t current_offset;
     quicrq_congestion_control_enum congestion_control_mode;
+    uint64_t end_of_congestion_group_id;
     int is_object_complete;
     int is_media_complete;
     int is_sending_object;
@@ -202,15 +204,6 @@ int quicrq_fragment_publisher_fn(
 
 int quicrq_fragment_is_ready_to_send(void* v_media_ctx, size_t data_max_size, uint64_t current_time);
 
-
-/* Evaluate whether the media context has backlog, and check
-* whether the current object should be skipped.
-*/
-int quicrq_fragment_datagram_publisher_object_eval(
-    quicrq_stream_ctx_t* stream_ctx,
-    quicrq_fragment_publisher_context_t* media_ctx, int* should_skip, uint64_t current_time);
-
-
 /* datagram_publisher_check_object:
  * evaluate and if necessary progress the "current fragment" pointer.
  * After this evaluation, expect the following results:
@@ -292,14 +285,15 @@ int quicrq_publish_fragment_cached_media(quicrq_ctx_t* qr_ctx,
     quicrq_fragment_cache_t* cache_ctx, const uint8_t* url, const size_t url_length,
     int is_local_object_source, int is_cache_real_time);
 
-/* Evaluation of backlog for single stream transmission */
-int quicrq_fragment_evaluate_backlog(quicrq_fragment_publisher_context_t* media_ctx);
+/* Evaluation of congestion for single stream transmission */
+int quicrq_evaluate_stream_congestion(quicrq_fragment_publisher_context_t* media_ctx, uint64_t current_time);
 
-/* Checking congestion in warp transmission mode */
-int quicrq_evaluate_warp_backlog(quicrq_uni_stream_ctx_t* uni_stream_ctx, quicrq_fragment_publisher_context_t* media_ctx);
+/* Evaluation of congestion in warp transmission mode */
+int quicrq_evaluate_warp_congestion(quicrq_uni_stream_ctx_t* uni_stream_ctx, quicrq_fragment_publisher_context_t* media_ctx,
+    size_t next_object_size, uint8_t flags, uint64_t current_time);
 
-/* Backlog evaluation in datagram mode */
-int quicrq_evaluate_datagram_backlog(quicrq_fragment_publisher_context_t* media_ctx, uint64_t current_time);
+/* Evaluation of congestion in datagram mode */
+int quicrq_evaluate_datagram_congestion(quicrq_stream_ctx_t* stream_ctx, quicrq_fragment_publisher_context_t* media_ctx, uint64_t current_time);
 
 #ifdef __cplusplus
 }

--- a/lib/quicrq_fragment.h
+++ b/lib/quicrq_fragment.h
@@ -68,6 +68,7 @@ typedef struct st_quicrq_fragment_publisher_context_t {
     uint64_t current_group_id;
     uint64_t current_object_id;
     size_t current_offset;
+    quicrq_congestion_control_enum congestion_control_mode;
     int is_object_complete;
     int is_media_complete;
     int is_sending_object;
@@ -290,6 +291,15 @@ void quicrq_fragment_publisher_delete(void* v_pub_ctx);
 int quicrq_publish_fragment_cached_media(quicrq_ctx_t* qr_ctx,
     quicrq_fragment_cache_t* cache_ctx, const uint8_t* url, const size_t url_length,
     int is_local_object_source, int is_cache_real_time);
+
+/* Evaluation of backlog for single stream transmission */
+int quicrq_fragment_evaluate_backlog(quicrq_fragment_publisher_context_t* media_ctx);
+
+/* Checking congestion in warp transmission mode */
+int quicrq_evaluate_warp_backlog(quicrq_uni_stream_ctx_t* uni_stream_ctx, quicrq_fragment_publisher_context_t* media_ctx);
+
+/* Backlog evaluation in datagram mode */
+int quicrq_evaluate_datagram_backlog(quicrq_fragment_publisher_context_t* media_ctx, uint64_t current_time);
 
 #ifdef __cplusplus
 }

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -602,7 +602,7 @@ struct st_quicrq_ctx_t {
     /* Count of media fragments received with numbers < start point */
     uint64_t useless_fragments;
     /* Control how enable congestion control -- mostly for testability */
-    quicrq_congestion_control_enum congestion_control_mode : 1;
+    quicrq_congestion_control_enum congestion_control_mode;
 };
 
 quicrq_stream_ctx_t* quicrq_find_or_create_stream(

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -601,8 +601,8 @@ struct st_quicrq_ctx_t {
     uint64_t extra_repeat_delay;
     /* Count of media fragments received with numbers < start point */
     uint64_t useless_fragments;
-    /* Control whether to enable congestion control -- mostly for testability */
-    unsigned int do_congestion_control : 1;
+    /* Control how enable congestion control -- mostly for testability */
+    quicrq_congestion_control_enum congestion_control_mode : 1;
 };
 
 quicrq_stream_ctx_t* quicrq_find_or_create_stream(

--- a/lib/reassembly.c
+++ b/lib/reassembly.c
@@ -361,6 +361,10 @@ int quicrq_reassembly_update_start_point(quicrq_reassembly_context_t* reassembly
                 reassembly_ctx->next_group_id += 1;
                 reassembly_ctx->next_object_id = 0;
             }
+            else {
+                /* The next group start segment is present, but there is a gap. */
+                break;
+            }
         }
         if (object == NULL || object->reassembled == NULL) {
             break;

--- a/quicrq_lib/quicrq_lib.vcxproj
+++ b/quicrq_lib/quicrq_lib.vcxproj
@@ -19,6 +19,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\lib\congestion.c" />
     <ClCompile Include="..\lib\fragment.c" />
     <ClCompile Include="..\lib\object_consumer.c" />
     <ClCompile Include="..\lib\object_source.c" />

--- a/quicrq_lib/quicrq_lib.vcxproj.filters
+++ b/quicrq_lib/quicrq_lib.vcxproj.filters
@@ -36,6 +36,9 @@
     <ClCompile Include="..\lib\fragment.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\lib\congestion.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\lib\quicrq_relay_internal.h">

--- a/src/quicrq_app.c
+++ b/src/quicrq_app.c
@@ -390,7 +390,7 @@ int quic_app_loop(picoquic_quic_config_t* config,
     int mode,
     const char* server_name,
     quicrq_transport_mode_enum transport_mode,
-    int congestion_mode,
+    quicrq_congestion_control_enum congestion_control_mode,
     int server_port,
     char const* scenario)
 {
@@ -427,7 +427,7 @@ int quic_app_loop(picoquic_quic_config_t* config,
         }
         else {
             /* Enable congestion control or not, based on CLI choice */
-            quicrq_enable_congestion_control(cb_ctx.qr_ctx, congestion_mode);
+            quicrq_enable_congestion_control(cb_ctx.qr_ctx, congestion_control_mode);
 
             /* Setting logs, etc. */
             quicrq_set_quic(cb_ctx.qr_ctx, quic);
@@ -570,7 +570,7 @@ int main(int argc, char** argv)
             switch (opt) {
             case 'f':
                 congestion_mode = atoi(optarg);
-                if (congestion_mode <= 0 || congestion_mode > 1) {
+                if (congestion_mode <= 0 || congestion_mode >= quicrq_congestion_control_max) {
                     fprintf(stderr, "Invalid congestion mode: %s\n", optarg);
                     usage();
                 }
@@ -659,7 +659,7 @@ int main(int argc, char** argv)
     }
 
     /* Run */
-    ret = quic_app_loop(&config, mode, server_name, transport_mode, congestion_mode, server_port, scenario);
+    ret = quic_app_loop(&config, mode, server_name, transport_mode, (quicrq_congestion_control_enum)congestion_mode, server_port, scenario);
     /* Clean up */
     picoquic_config_clear(&config);
     /* Exit */

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -38,6 +38,7 @@ static const quicrq_test_def_t test_table[] =
     { "congestion_datagram_recv", quicrq_congestion_datagram_recv_test },
     { "congestion_datagram_rloss", quicrq_congestion_datagram_rloss_test },
     { "congestion_datagram_zero", quicrq_congestion_datagram_zero_test },
+    { "congestion_datagram_g", quicrq_congestion_datagram_g_test },
     { "media_video1", quicrq_media_video1_test },
     { "media_video1_rt", quicrq_media_video1_rt_test },
     { "media_audio1", quicrq_media_audio1_test },

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -31,6 +31,7 @@ static const quicrq_test_def_t test_table[] =
     { "congestion_basic_recv", quicrq_congestion_basic_recv_test },
     { "congestion_basic_loss", quicrq_congestion_basic_loss_test },
     { "congestion_basic_zero", quicrq_congestion_basic_zero_test },
+    { "congestion_basic_g", quicrq_congestion_basic_g_test },
     { "congestion_datagram", quicrq_congestion_datagram_test },
     { "congestion_datagram_half", quicrq_congestion_datagram_half_test },
     { "congestion_datagram_loss", quicrq_congestion_datagram_loss_test },
@@ -111,6 +112,7 @@ static const quicrq_test_def_t test_table[] =
     { "warp_basic_client", quicrq_warp_basic_client_test },
     { "warp_triangle", quicrq_triangle_warp_test },
     { "warp_congestion", quicrq_congestion_warp_test },
+    { "warp_congestion_g", quicrq_congestion_warp_g_test },
     { "warp_relay", quicrq_warp_relay_test },
     { "warp_basic_loss", quicrq_warp_basic_loss_test },
     { "warp_relay_loss", quicrq_warp_relay_loss_test }

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -344,7 +344,7 @@ int quicrq_congestion_test_one(int is_real_time, quicrq_transport_mode_enum tran
                         }
                         else if (spec->max_delay_target > 0 &&
                             delay_max > spec->max_delay_target) {
-                            DBG_PRINTF("Average delay %" PRIu64 ", exceeds %" PRIu64,
+                            DBG_PRINTF("Max delay %" PRIu64 ", exceeds %" PRIu64,
                                 delay_max, spec->max_delay_target);
                             ret = -1;
                         }
@@ -450,6 +450,24 @@ int quicrq_congestion_basic_zero_test()
     spec.average_delay_target = 26000;
     spec.max_delay_target = 110000;
     spec.congestion_control_mode = quicrq_congestion_control_delay;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_single_stream, &spec);
+
+    return ret;
+}
+
+int quicrq_congestion_basic_g_test()
+{
+    quicrq_congestion_test_t spec = { 0 };
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 60;
+    spec.min_loss_flag = 0x82;
+    spec.average_delay_target = 550000;
+    spec.max_delay_target = 1150000;
+    spec.congestion_control_mode = quicrq_congestion_control_group;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_single_stream, &spec);
 
@@ -578,6 +596,24 @@ int quicrq_congestion_warp_test()
     spec.average_delay_target = 210000;
     spec.max_delay_target = 700000;
     spec.congestion_control_mode = quicrq_congestion_control_delay;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_warp, &spec);
+
+    return ret;
+}
+
+int quicrq_congestion_warp_g_test()
+{
+    quicrq_congestion_test_t spec = { 0 };
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 73;
+    spec.min_loss_flag = 0x82;
+    spec.average_delay_target = 540000;
+    spec.max_delay_target = 1150000;
+    spec.congestion_control_mode = quicrq_congestion_control_group;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_warp, &spec);
 

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -144,8 +144,8 @@ int quicrq_congestion_test_one(int is_real_time, quicrq_transport_mode_enum tran
     int half_congestion = spec->congestion_mode == congestion_mode_half;
     uint64_t client2_close_time = UINT64_MAX;
 
-    (void)picoquic_sprintf(text_log_name, sizeof(text_log_name), &nb_log_chars, "congestion_textlog-%d-%c-%llx-%d-%d.txt", is_real_time,
-        quicrq_transport_mode_to_letter(transport_mode),
+    (void)picoquic_sprintf(text_log_name, sizeof(text_log_name), &nb_log_chars, "congestion_textlog-%d-%c%d-%llx-%d-%d.txt", is_real_time,
+        quicrq_transport_mode_to_letter(transport_mode), (int)spec->congestion_control_mode,
         (unsigned long long)spec->simulate_losses, spec->congested_receiver, (int)spec->congestion_mode);
     /* TODO: name shall indicate the triangle configuration */
     ret = test_media_derive_file_names((uint8_t*)QUICRQ_TEST_BASIC_SOURCE, strlen(QUICRQ_TEST_BASIC_SOURCE),
@@ -584,6 +584,24 @@ int quicrq_congestion_datagram_zero_test()
     return ret;
 }
 
+int quicrq_congestion_datagram_g_test()
+{
+    quicrq_congestion_test_t spec = { 0 };
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 73;
+    spec.min_loss_flag = 0x82;
+    spec.average_delay_target = 550000;
+    spec.max_delay_target = 1150000;
+    spec.congestion_control_mode = quicrq_congestion_control_group;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_datagram, &spec);
+
+    return ret;
+}
+
 int quicrq_congestion_warp_test()
 {
     quicrq_congestion_test_t spec = { 0 };
@@ -609,7 +627,7 @@ int quicrq_congestion_warp_g_test()
 
     spec.simulate_losses = 0;
     spec.congested_receiver = 0;
-    spec.max_drops = 73;
+    spec.max_drops = 60;
     spec.min_loss_flag = 0x82;
     spec.average_delay_target = 540000;
     spec.max_delay_target = 1150000;

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -24,10 +24,10 @@ typedef struct st_quicrq_congestion_test_t {
     int congested_receiver;
     int max_drops;
     congestion_mode_enum congestion_mode;
+    quicrq_congestion_control_enum congestion_control_mode;
     uint8_t min_loss_flag;
     uint64_t average_delay_target;
     uint64_t max_delay_target;
-
 } quicrq_congestion_test_t;
 
 /* Create a test network */
@@ -63,7 +63,7 @@ quicrq_test_config_t* quicrq_test_congestion_config_create(quicrq_congestion_tes
         }
 
         for (int i = 0; i < 3; i++) {
-            quicrq_enable_congestion_control(config->nodes[i], 1);
+            quicrq_enable_congestion_control(config->nodes[i], spec->congestion_control_mode);
         }
     }
 
@@ -375,6 +375,7 @@ int quicrq_congestion_basic_test()
     spec.min_loss_flag = 0x82;
     spec.average_delay_target = 250000;
     spec.max_delay_target = 700000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_single_stream, &spec);
 
@@ -393,6 +394,7 @@ int quicrq_congestion_basic_half_test()
     spec.congestion_mode = congestion_mode_half;
     spec.average_delay_target = 110000;
     spec.max_delay_target = 500000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_single_stream, &spec);
 
@@ -410,6 +412,7 @@ int quicrq_congestion_basic_loss_test()
     spec.min_loss_flag = 0x82;
     spec.average_delay_target = 210000;
     spec.max_delay_target = 700000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_single_stream, &spec);
 
@@ -427,6 +430,7 @@ int quicrq_congestion_basic_recv_test()
     spec.min_loss_flag = 0x82;
     spec.average_delay_target = 215000;
     spec.max_delay_target = 580000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_single_stream, &spec);
 
@@ -445,6 +449,7 @@ int quicrq_congestion_basic_zero_test()
     spec.congestion_mode = congestion_mode_zero;
     spec.average_delay_target = 26000;
     spec.max_delay_target = 110000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_single_stream, &spec);
 
@@ -462,6 +467,7 @@ int quicrq_congestion_datagram_test()
     spec.min_loss_flag = 0x82;
     spec.average_delay_target = 210000;
     spec.max_delay_target = 700000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_datagram, &spec);
 
@@ -480,6 +486,7 @@ int quicrq_congestion_datagram_half_test()
     spec.congestion_mode = congestion_mode_half;
     spec.average_delay_target = 125000;
     spec.max_delay_target = 610000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_datagram, &spec);
 
@@ -497,6 +504,7 @@ int quicrq_congestion_datagram_loss_test()
     spec.min_loss_flag = 0x82;
     spec.average_delay_target = 230000;
     spec.max_delay_target = 820000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_datagram, &spec);
 
@@ -514,6 +522,7 @@ int quicrq_congestion_datagram_recv_test()
     spec.min_loss_flag = 0x82;
     spec.average_delay_target = 220000;
     spec.max_delay_target = 760000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_datagram, &spec);
 
@@ -531,6 +540,7 @@ int quicrq_congestion_datagram_rloss_test()
     spec.min_loss_flag = 0x82;
     spec.average_delay_target = 220000;
     spec.max_delay_target = 800000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_datagram, &spec);
 
@@ -549,6 +559,7 @@ int quicrq_congestion_datagram_zero_test()
     spec.congestion_mode = congestion_mode_zero;
     spec.average_delay_target = 26000;
     spec.max_delay_target = 115000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_datagram, &spec);
 
@@ -566,6 +577,7 @@ int quicrq_congestion_warp_test()
     spec.min_loss_flag = 0x82;
     spec.average_delay_target = 210000;
     spec.max_delay_target = 700000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_warp, &spec);
 

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -19,6 +19,7 @@ extern "C" {
     int quicrq_congestion_basic_loss_test();
     int quicrq_congestion_basic_zero_test();
     int quicrq_congestion_basic_half_test();
+    int quicrq_congestion_basic_g_test();
     int quicrq_congestion_datagram_test();
     int quicrq_congestion_datagram_loss_test();
     int quicrq_congestion_datagram_recv_test();
@@ -96,6 +97,7 @@ extern "C" {
     int quicrq_warp_basic_client_test();
     int quicrq_triangle_warp_test();
     int quicrq_congestion_warp_test();
+    int quicrq_congestion_warp_g_test();
     int quicrq_warp_relay_test();
     int quicrq_warp_basic_loss_test();
     int quicrq_warp_relay_loss_test();

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -26,6 +26,7 @@ extern "C" {
     int quicrq_congestion_datagram_rloss_test();
     int quicrq_congestion_datagram_zero_test();
     int quicrq_congestion_datagram_half_test();
+    int quicrq_congestion_datagram_g_test();
     int quicrq_datagram_basic_test();
     int quicrq_datagram_loss_test();
     int quicrq_datagram_extra_test();


### PR DESCRIPTION
As is, only verified for single stream and warp transmission modes. We need to verify it for datagrams before merging. In fact, we probably need to port a dozen more tests to be really sure.

The first impression is that it works, there are fewer packets dropped than with the "delay based" congestion that we are currently using, but the queuing delays are much longer. That's expected: if a transmission is slow, we will build up a queue until the beginning of the next group of blocks arrive. On the plus side, the algorithm is much more robust against improper setting of flags in the client, e.g., mistakenly marking P frames as "can be dropped", which causes loss of the whole block.