### PR TITLE
Test the "skip ahead" variant of warp congestion

### DIFF
--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -614,6 +614,12 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(warp_congestion_gs) {
+			int ret = quicrq_congestion_warp_gs_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(warp_relay) {
 			int ret = quicrq_warp_relay_test();
 

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -227,6 +227,12 @@ typedef int (*quicrq_object_stream_consumer_fn)(
 typedef struct st_quicrq_object_stream_consumer_ctx quicrq_object_stream_consumer_ctx;
 
 typedef enum {
+    quicrq_subscribe_out_of_order = 0,
+    quicrq_subscribe_in_order,
+    quicrq_subscribe_in_order_skip_to_group_ahead
+} quicrq_subscribe_order_enum;
+
+typedef enum {
     quicrq_subscribe_intent_current_group = 0,
     quicrq_subscribe_intent_next_group = 1,
     quicrq_subscribe_intent_start_point = 2
@@ -240,7 +246,7 @@ typedef struct st_quicrq_subscribe_intent_t {
 
 quicrq_object_stream_consumer_ctx* quicrq_subscribe_object_stream(quicrq_cnx_ctx_t* cnx_ctx,
     const uint8_t* url, size_t url_length, quicrq_transport_mode_enum transport_mode,
-    int in_order_required, quicrq_subscribe_intent_t * intent,
+    quicrq_subscribe_order_enum order_required, quicrq_subscribe_intent_t * intent,
     quicrq_object_stream_consumer_fn media_object_consumer_fn, void* media_object_ctx);
 
 void quicrq_unsubscribe_object_stream(quicrq_object_stream_consumer_ctx* subscribe_ctx);

--- a/include/quicrq_reassembly.h
+++ b/include/quicrq_reassembly.h
@@ -73,6 +73,9 @@ int quicrq_reassembly_learn_final_object_id(
 /* Find the object number of the last reassembled object */
 uint64_t quicrq_reassembly_object_id_last(quicrq_reassembly_context_t* reassembly_ctx);
 
+/* Find the number of objects in a group, returns 0 if unknown */
+uint64_t quicrq_reassembly_get_object_count(quicrq_reassembly_context_t* object_list, uint64_t group_id);
+
 /* Initialize the reassembly context, supposedly zero on input.
  */
 void quicrq_reassembly_init(quicrq_reassembly_context_t* reassembly_ctx);

--- a/lib/object_consumer.c
+++ b/lib/object_consumer.c
@@ -40,7 +40,6 @@ int quicrq_media_object_bridge_ready(
     int ignore = 1;
     quicrq_object_stream_consumer_ctx* bridge_ctx = (quicrq_object_stream_consumer_ctx*)media_ctx;
 
-#if 1
     /* TODO: for some streams, we may be able to "jump ahead" and
         * use the latest object without waiting for the full sequence */
     /* if in sequence, deliver the object to the application. */
@@ -68,19 +67,7 @@ int quicrq_media_object_bridge_ready(
             current_time, group_id, object_id,
             data, data_length,  &properties, 0, 0);
     }
-#else
-    if ((bridge_ctx->in_order_required && object_mode != quicrq_reassembly_object_peek) ||
-        (!bridge_ctx->in_order_required && object_mode != quicrq_reassembly_object_repair)){
-        /* Deliver to the application */
-        quicrq_object_stream_consumer_properties_t properties = { 0 };
-        properties.flags = flags;
-        ret = bridge_ctx->object_stream_consumer_fn(
-            quicrq_media_datagram_ready,
-            bridge_ctx->object_stream_consumer_ctx,
-            current_time, group_id, object_id,
-            data, data_length,  &properties, 0, 0);
-    }
-#endif
+
     return ret;
 }
 

--- a/lib/reassembly.c
+++ b/lib/reassembly.c
@@ -126,6 +126,18 @@ static quicrq_reassembly_object_t* quicrq_object_find(quicrq_reassembly_context_
     return object;
 }
 
+/* Check whether the number of objects in the next group is known */
+uint64_t quicrq_reassembly_get_object_count(quicrq_reassembly_context_t* object_list, uint64_t group_id)
+{
+    /* Find whether the next object is in cache */
+    uint64_t nb_objects = 0;
+    quicrq_reassembly_object_t* object = quicrq_object_find(object_list, group_id + 1, 0);
+    if (object != NULL) {
+        nb_objects = object->nb_objects_previous_group;
+    }
+    return nb_objects;
+}
+
 /* Management of the list of objects undergoing reassembly, object-id based logic */
 static quicrq_reassembly_packet_t* quicrq_reassembly_object_create_packet(
     quicrq_reassembly_object_t* object,

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -119,6 +119,7 @@ static const quicrq_test_def_t test_table[] =
     { "warp_triangle", quicrq_triangle_warp_test },
     { "warp_congestion", quicrq_congestion_warp_test },
     { "warp_congestion_g", quicrq_congestion_warp_g_test },
+    { "warp_congestion_gs", quicrq_congestion_warp_gs_test },
     { "warp_relay", quicrq_warp_relay_test },
     { "warp_basic_loss", quicrq_warp_basic_loss_test },
     { "warp_relay_loss", quicrq_warp_relay_loss_test }

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -25,10 +25,22 @@ typedef struct st_quicrq_congestion_test_t {
     int max_drops;
     congestion_mode_enum congestion_mode;
     quicrq_congestion_control_enum congestion_control_mode;
+    quicrq_subscribe_order_enum subscribe_order;
     uint8_t min_loss_flag;
     uint64_t average_delay_target;
     uint64_t max_delay_target;
 } quicrq_congestion_test_t;
+
+static const quicrq_congestion_test_t congestion_test_default = {
+    0, /* No loss */
+    0, /* receiver not congested */
+    0, /* No drops */
+    congestion_mode_full,
+    quicrq_subscribe_in_order,
+    0x82, /* Default flag */
+    0, /* Average delay needs to be set per test */
+    0, /* Max delay needs to be set per test */
+};
 
 /* Create a test network */
 quicrq_test_config_t* quicrq_test_congestion_config_create(quicrq_congestion_test_t * spec)
@@ -143,14 +155,16 @@ int quicrq_congestion_test_one(int is_real_time, quicrq_transport_mode_enum tran
     int partial_closure = 0;
     int half_congestion = spec->congestion_mode == congestion_mode_half;
     uint64_t client2_close_time = UINT64_MAX;
+    char test_id[256];
 
-    (void)picoquic_sprintf(text_log_name, sizeof(text_log_name), &nb_log_chars, "congestion_textlog-%d-%c%d-%llx-%d-%d.txt", is_real_time,
+    /* Create unique names for logs and results */
+    (void)picoquic_sprintf(test_id, sizeof(test_id), NULL, "congestion-%d-%c%d-%d-%llx-%d-%d", is_real_time, 
         quicrq_transport_mode_to_letter(transport_mode), (int)spec->congestion_control_mode,
+        (int) spec->subscribe_order,
         (unsigned long long)spec->simulate_losses, spec->congested_receiver, (int)spec->congestion_mode);
-    /* TODO: name shall indicate the triangle configuration */
-    ret = test_media_derive_file_names((uint8_t*)QUICRQ_TEST_BASIC_SOURCE, strlen(QUICRQ_TEST_BASIC_SOURCE),
-        transport_mode, is_real_time, 1,
-        result_file_name, result_log_name, sizeof(result_file_name));
+    (void)picoquic_sprintf(text_log_name, sizeof(text_log_name), &nb_log_chars, "%s_textlog.txt", test_id);
+    (void)picoquic_sprintf(result_file_name, sizeof(result_file_name), NULL, "%s_video1.bin", test_id);
+    (void)picoquic_sprintf(result_log_name, sizeof(result_log_name), NULL, "%s_video1.csv", test_id);
 
     if (config == NULL) {
         ret = -1;
@@ -215,8 +229,8 @@ int quicrq_congestion_test_one(int is_real_time, quicrq_transport_mode_enum tran
         /* Create a subscription to the test source on client # 2*/
         if (ret == 0) {
             test_object_stream_ctx_t* object_stream_ctx = NULL;
-            object_stream_ctx = test_object_stream_subscribe(cnx_ctx_2, (const uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
-                strlen(QUICRQ_TEST_BASIC_SOURCE), transport_mode, result_file_name, result_log_name);
+            object_stream_ctx = test_object_stream_subscribe_ex(cnx_ctx_2, (const uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
+                strlen(QUICRQ_TEST_BASIC_SOURCE), transport_mode, spec->subscribe_order, NULL, result_file_name, result_log_name);
             if (object_stream_ctx == NULL) {
                 ret = -1;
             }
@@ -366,7 +380,7 @@ int quicrq_congestion_test_one(int is_real_time, quicrq_transport_mode_enum tran
 
 int quicrq_congestion_basic_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -384,7 +398,7 @@ int quicrq_congestion_basic_test()
 
 int quicrq_congestion_basic_half_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -403,7 +417,7 @@ int quicrq_congestion_basic_half_test()
 
 int quicrq_congestion_basic_loss_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0x7080;
@@ -421,7 +435,7 @@ int quicrq_congestion_basic_loss_test()
 
 int quicrq_congestion_basic_recv_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -439,7 +453,7 @@ int quicrq_congestion_basic_recv_test()
 
 int quicrq_congestion_basic_zero_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -458,7 +472,7 @@ int quicrq_congestion_basic_zero_test()
 
 int quicrq_congestion_basic_g_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -476,7 +490,7 @@ int quicrq_congestion_basic_g_test()
 
 int quicrq_congestion_datagram_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -494,7 +508,7 @@ int quicrq_congestion_datagram_test()
 
 int quicrq_congestion_datagram_half_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -513,7 +527,7 @@ int quicrq_congestion_datagram_half_test()
 
 int quicrq_congestion_datagram_loss_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0x7080;
@@ -531,7 +545,7 @@ int quicrq_congestion_datagram_loss_test()
 
 int quicrq_congestion_datagram_recv_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -549,7 +563,7 @@ int quicrq_congestion_datagram_recv_test()
 
 int quicrq_congestion_datagram_rloss_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0x7080;
@@ -567,7 +581,7 @@ int quicrq_congestion_datagram_rloss_test()
 
 int quicrq_congestion_datagram_zero_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -586,7 +600,7 @@ int quicrq_congestion_datagram_zero_test()
 
 int quicrq_congestion_datagram_g_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -604,7 +618,7 @@ int quicrq_congestion_datagram_g_test()
 
 int quicrq_congestion_warp_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -622,7 +636,7 @@ int quicrq_congestion_warp_test()
 
 int quicrq_congestion_warp_g_test()
 {
-    quicrq_congestion_test_t spec = { 0 };
+    quicrq_congestion_test_t spec = congestion_test_default;
     int ret = 0;
 
     spec.simulate_losses = 0;
@@ -632,6 +646,25 @@ int quicrq_congestion_warp_g_test()
     spec.average_delay_target = 540000;
     spec.max_delay_target = 1150000;
     spec.congestion_control_mode = quicrq_congestion_control_group;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_warp, &spec);
+
+    return ret;
+}
+
+int quicrq_congestion_warp_gs_test()
+{
+    quicrq_congestion_test_t spec = congestion_test_default;
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 62;
+    spec.min_loss_flag = 0x82;
+    spec.average_delay_target = 530000;
+    spec.max_delay_target = 1120000;
+    spec.congestion_control_mode = quicrq_congestion_control_group;
+    spec.subscribe_order = quicrq_subscribe_in_order_skip_to_group_ahead;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_warp, &spec);
 

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -36,6 +36,7 @@ static const quicrq_congestion_test_t congestion_test_default = {
     0, /* receiver not congested */
     0, /* No drops */
     congestion_mode_full,
+    quicrq_congestion_control_delay,
     quicrq_subscribe_in_order,
     0x82, /* Default flag */
     0, /* Average delay needs to be set per test */

--- a/tests/quicrq_test_internal.h
+++ b/tests/quicrq_test_internal.h
@@ -178,7 +178,8 @@ int test_media_consumer_init_callback(quicrq_stream_ctx_t* stream_ctx, const uin
 test_object_stream_ctx_t* test_object_stream_subscribe(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length, 
     quicrq_transport_mode_enum transport_mode, char const* media_result_file, char const* media_result_log);
 test_object_stream_ctx_t* test_object_stream_subscribe_ex(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length,
-    quicrq_transport_mode_enum transport_mode,  quicrq_subscribe_intent_t* intent, char const* media_result_file, char const* media_result_log);
+    quicrq_transport_mode_enum transport_mode, quicrq_subscribe_order_enum order_required,
+    quicrq_subscribe_intent_t* intent, char const* media_result_file, char const* media_result_log);
 void test_object_stream_unsubscribe(test_object_stream_ctx_t* cons_ctx);
 int test_media_object_source_iterate(test_media_object_source_context_t* object_pub_ctx, uint64_t current_time, int * is_active);
 uint64_t test_media_object_source_next_time(test_media_object_source_context_t* object_pub_ctx, uint64_t current_time);

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -104,6 +104,7 @@ extern "C" {
     int quicrq_triangle_warp_test();
     int quicrq_congestion_warp_test();
     int quicrq_congestion_warp_g_test();
+    int quicrq_congestion_warp_gs_test();
     int quicrq_warp_relay_test();
     int quicrq_warp_basic_loss_test();
     int quicrq_warp_relay_loss_test();

--- a/tests/test_media.c
+++ b/tests/test_media.c
@@ -988,7 +988,8 @@ int test_object_stream_consumer_cb(
 }
 
 test_object_stream_ctx_t* test_object_stream_subscribe_ex(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length,
-    quicrq_transport_mode_enum transport_mode, quicrq_subscribe_intent_t * intent, char const* media_result_file, char const* media_result_log)
+    quicrq_transport_mode_enum transport_mode, quicrq_subscribe_order_enum order_required, quicrq_subscribe_intent_t * intent,
+    char const* media_result_file, char const* media_result_log)
 {
     int ret = 0;
     /* Open and initialize result file and log file */
@@ -1008,7 +1009,8 @@ test_object_stream_ctx_t* test_object_stream_subscribe_ex(quicrq_cnx_ctx_t* cnx_
             ret = -1;
         }
         else {
-            cons_ctx->media_ctx = quicrq_subscribe_object_stream(cnx_ctx, url, url_length, transport_mode, 1, intent, test_object_stream_consumer_cb, cons_ctx);
+            cons_ctx->media_ctx = quicrq_subscribe_object_stream(cnx_ctx, url, url_length, transport_mode, 
+                order_required, intent, test_object_stream_consumer_cb, cons_ctx);
             if (cons_ctx->media_ctx == NULL) {
                 ret = -1;
             }
@@ -1025,7 +1027,7 @@ test_object_stream_ctx_t* test_object_stream_subscribe_ex(quicrq_cnx_ctx_t* cnx_
 test_object_stream_ctx_t* test_object_stream_subscribe(quicrq_cnx_ctx_t* cnx_ctx, const uint8_t* url, size_t url_length,
     quicrq_transport_mode_enum transport_mode, char const* media_result_file, char const* media_result_log)
 {
-    return test_object_stream_subscribe_ex(cnx_ctx, url, url_length, transport_mode,
+    return test_object_stream_subscribe_ex(cnx_ctx, url, url_length, transport_mode, quicrq_subscribe_in_order,
         NULL, media_result_file, media_result_log);
 }
 

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -64,9 +64,26 @@ quicrq_test_config_t* quicrq_test_triangle_config_create(uint64_t simulate_loss,
     return config;
 }
 
+typedef struct st_quicrq_triangle_test_spec_t {
+    int is_real_time;
+    uint64_t simulate_losses;
+    uint64_t extra_delay;
+    uint64_t start_point;
+    int test_cache_clear;
+    int test_intent;
+} quicrq_triangle_test_spec_t;
+
+static const quicrq_triangle_test_spec_t triangle_test_default = {
+    1, /* real time */
+    0, /* 0 loss */
+    0, /* 0 delay */
+    0, /* start from beginning */
+    0, /* Do not clear the cache */
+    0  /* Intent: start from beginning */
+};
+
 /* Basic relay test */
-int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transport_mode, uint64_t simulate_losses, uint64_t extra_delay, uint64_t start_point,
-    int test_cache_clear, int test_intent)
+int quicrq_triangle_test_one(quicrq_transport_mode_enum transport_mode, quicrq_triangle_test_spec_t * spec)
 {
     int ret = 0;
     int nb_steps = 0;
@@ -74,7 +91,7 @@ int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transp
     int is_closed = 0;
     const uint64_t max_time = 360000000;
     const int max_inactive = 128;
-    quicrq_test_config_t* config = quicrq_test_triangle_config_create(simulate_losses, extra_delay);
+    quicrq_test_config_t* config = quicrq_test_triangle_config_create(spec->simulate_losses, spec->extra_delay);
     quicrq_cnx_ctx_t* cnx_ctx_1 = NULL;
     quicrq_cnx_ctx_t* cnx_ctx_2 = NULL;
     char media_source_path[512];
@@ -90,10 +107,10 @@ int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transp
     char test_id[256];
 
     /* Create unique names for los and results */
-    (void)picoquic_sprintf(test_id, sizeof(test_id), NULL, "triangle-%d-%c-%llx-%llu-%llu-%d-%d", is_real_time, 
+    (void)picoquic_sprintf(test_id, sizeof(test_id), NULL, "triangle-%d-%c-%llx-%llu-%llu-%d-%d", spec->is_real_time, 
         quicrq_transport_mode_to_letter(transport_mode),
-        (unsigned long long)simulate_losses, (unsigned long long)extra_delay,
-        (unsigned long long)start_point, test_cache_clear, test_intent);
+        (unsigned long long)spec->simulate_losses, (unsigned long long)spec->extra_delay,
+        (unsigned long long)spec->start_point, spec->test_cache_clear, spec->test_intent);
     (void)picoquic_sprintf(text_log_name, sizeof(text_log_name), &nb_log_chars, "%s_textlog.txt", test_id);
     (void)picoquic_sprintf(result_file_name, sizeof(result_file_name), NULL, "%s_video1.bin", test_id);
     (void)picoquic_sprintf(result_log_name, sizeof(result_log_name), NULL, "%s_video1.csv", test_id);
@@ -126,12 +143,12 @@ int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transp
         quicrq_media_object_source_properties_t properties = { 0 };
         int publish_node = 1;
 
-        if (test_cache_clear) {
+        if (spec->test_cache_clear) {
             properties.use_real_time_caching = 1;
             quicrq_set_cache_duration(config->nodes[0], 5000000);
         }
 
-        if (start_point != 0) {
+        if (spec->start_point != 0) {
             properties.start_group_id = 1;
             properties.start_object_id = 0;
             start_group_intent = 1;
@@ -139,7 +156,7 @@ int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transp
         }
 
         config->object_sources[0] = test_media_object_source_publish_ex(config->nodes[publish_node], (uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
-            strlen(QUICRQ_TEST_BASIC_SOURCE), media_source_path, NULL, is_real_time, config->simulated_time, &properties);
+            strlen(QUICRQ_TEST_BASIC_SOURCE), media_source_path, NULL, spec->is_real_time, config->simulated_time, &properties);
         if (config->object_sources[0] == NULL) {
             ret = -1;
         }
@@ -172,7 +189,7 @@ int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transp
     }
 
     if (ret == 0) {
-        if (test_intent > 0) {
+        if (spec->test_intent > 0) {
             config->next_test_event_time = 4000000;
         } else {
             /* Create a subscription to the test source on client # 2*/
@@ -199,7 +216,7 @@ int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transp
             /* Create a subscription to the test source on client # 2*/
             test_object_stream_ctx_t* object_stream_ctx = NULL;
             quicrq_subscribe_intent_t intent = { 0 };
-            intent.intent_mode = (quicrq_subscribe_intent_enum)(test_intent - 1);
+            intent.intent_mode = (quicrq_subscribe_intent_enum)(spec->test_intent - 1);
             switch (intent.intent_mode) {
             case quicrq_subscribe_intent_current_group:
                 start_group_intent = 1;
@@ -288,7 +305,7 @@ int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transp
         ret = -1;
     }
 
-    if (ret == 0 && test_cache_clear) {
+    if (ret == 0 && spec->test_cache_clear) {
         /* Check that relay sources are deleted after a sufficient timer */
         uint64_t cache_time = config->simulated_time + 10000000;
 
@@ -351,42 +368,53 @@ int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transp
 
 int quicrq_triangle_basic_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_single_stream, 0, 0, 0, 0, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_single_stream, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_basic_loss_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_single_stream, 0x7080, 0, 0, 0, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_single_stream, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_datagram_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0, 0, 0, 0, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_datagram_loss_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0x7080, 0, 0, 0, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_datagram_extra_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0x7080, 10000, 0, 0, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    spec.extra_delay = 10000;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_warp_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_warp, 0, 0, 0, 0, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_warp, &spec);
 
     return ret;
 }
@@ -400,133 +428,190 @@ int quicrq_triangle_warp_test()
  */
 int quicrq_triangle_start_point_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0x7080, 10000, 1, 0, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    spec.extra_delay = 10000;
+    spec.start_point = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_start_point_s_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_single_stream, 0x7080, 10000, 1, 0, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    spec.extra_delay = 10000;
+    spec.start_point = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_single_stream, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_start_point_w_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_warp, 0x7080, 10000, 1, 0, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    spec.extra_delay = 10000;
+    spec.start_point = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_warp, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_cache_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0, 0, 0, 1, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_cache_loss_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0x7080, 0, 0, 1, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    spec.test_cache_clear = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_cache_stream_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_single_stream, 0, 0, 0, 1, 0);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_single_stream, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_single_stream, 0, 0, 0, 1, 1);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_single_stream, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_nc_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_single_stream, 0, 0, 0, 0, 1);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_single_stream, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_datagram_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0, 0, 0, 1, 1);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_dg_nc_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0, 0, 0, 0, 1);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_loss_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0x7080, 0, 0, 1, 1);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_next_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0, 0, 0, 1, 2);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 2;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_next_s_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_single_stream, 0, 0, 0, 1, 2);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 2;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_single_stream, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_that_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_datagram, 0, 0, 0, 1, 3);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 3;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_datagram, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_that_s_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_single_stream, 0, 0, 0, 1, 3);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 3;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_single_stream, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_warp_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_warp, 0, 0, 0, 1, 1);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_warp, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_warp_nc_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_warp, 0, 0, 0, 0, 1);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_warp, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_warp_loss_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_warp, 0x7080, 0, 0, 1, 1);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_warp, &spec);
 
     return ret;
 }
 
 int quicrq_triangle_intent_warp_next_test()
 {
-    int ret = quicrq_triangle_test_one(1, quicrq_transport_mode_warp, 0, 0, 0, 1, 2);
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 2;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_warp, &spec);
 
     return ret;
 }

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -219,7 +219,7 @@ int quicrq_triangle_test_one(int is_real_time, quicrq_transport_mode_enum transp
                 break;
             }
             object_stream_ctx = test_object_stream_subscribe_ex(cnx_ctx_2, (const uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
-                strlen(QUICRQ_TEST_BASIC_SOURCE), transport_mode, &intent, result_file_name, result_log_name);
+                strlen(QUICRQ_TEST_BASIC_SOURCE), transport_mode, quicrq_subscribe_in_order, &intent, result_file_name, result_log_name);
             if (object_stream_ctx == NULL) {
                 ret = -1;
                 break;

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -71,6 +71,7 @@ typedef struct st_quicrq_triangle_test_spec_t {
     uint64_t start_point;
     int test_cache_clear;
     int test_intent;
+    quicrq_subscribe_order_enum subscribe_order;
 } quicrq_triangle_test_spec_t;
 
 static const quicrq_triangle_test_spec_t triangle_test_default = {
@@ -79,7 +80,8 @@ static const quicrq_triangle_test_spec_t triangle_test_default = {
     0, /* 0 delay */
     0, /* start from beginning */
     0, /* Do not clear the cache */
-    0  /* Intent: start from beginning */
+    0,  /* Intent: start from beginning */
+    quicrq_subscribe_in_order
 };
 
 /* Basic relay test */
@@ -106,7 +108,7 @@ int quicrq_triangle_test_one(quicrq_transport_mode_enum transport_mode, quicrq_t
     uint64_t start_object_intent = 0;
     char test_id[256];
 
-    /* Create unique names for los and results */
+    /* Create unique names for logs and results */
     (void)picoquic_sprintf(test_id, sizeof(test_id), NULL, "triangle-%d-%c-%llx-%llu-%llu-%d-%d", spec->is_real_time, 
         quicrq_transport_mode_to_letter(transport_mode),
         (unsigned long long)spec->simulate_losses, (unsigned long long)spec->extra_delay,
@@ -194,8 +196,10 @@ int quicrq_triangle_test_one(quicrq_transport_mode_enum transport_mode, quicrq_t
         } else {
             /* Create a subscription to the test source on client # 2*/
             test_object_stream_ctx_t* object_stream_ctx = NULL;
-            object_stream_ctx = test_object_stream_subscribe(cnx_ctx_2, (const uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
-                strlen(QUICRQ_TEST_BASIC_SOURCE), transport_mode, result_file_name, result_log_name);
+
+            object_stream_ctx = test_object_stream_subscribe_ex(cnx_ctx_2, (const uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
+                strlen(QUICRQ_TEST_BASIC_SOURCE), transport_mode, spec->subscribe_order, NULL, result_file_name, result_log_name);
+
             if (object_stream_ctx == NULL) {
                 ret = -1;
             }
@@ -236,7 +240,7 @@ int quicrq_triangle_test_one(quicrq_transport_mode_enum transport_mode, quicrq_t
                 break;
             }
             object_stream_ctx = test_object_stream_subscribe_ex(cnx_ctx_2, (const uint8_t*)QUICRQ_TEST_BASIC_SOURCE,
-                strlen(QUICRQ_TEST_BASIC_SOURCE), transport_mode, quicrq_subscribe_in_order, &intent, result_file_name, result_log_name);
+                strlen(QUICRQ_TEST_BASIC_SOURCE), transport_mode, spec->subscribe_order, &intent, result_file_name, result_log_name);
             if (object_stream_ctx == NULL) {
                 ret = -1;
                 break;

--- a/tests/twoways_test.c
+++ b/tests/twoways_test.c
@@ -191,7 +191,8 @@ int quicrq_twoways_test_one(int is_real_time, quicrq_transport_mode_enum transpo
                                 test_object_stream_ctx_t* object_stream_ctx = NULL;
                                 quicrq_subscribe_intent_t intent = { quicrq_subscribe_intent_current_group, 0, 0 };
                                 object_stream_ctx = test_object_stream_subscribe_ex(cnx_ctx[i], (const uint8_t*)target[source_id]->url,
-                                    target[source_id]->url_length, transport_mode, &intent, target[source_id]->target_bin, target[source_id]->target_csv);
+                                    target[source_id]->url_length, transport_mode, quicrq_subscribe_in_order,
+                                    &intent, target[source_id]->target_bin, target[source_id]->target_csv);
                                 if (object_stream_ctx == NULL) {
                                     ret = -1;
                                 }


### PR DESCRIPTION
Add a client mode in which the client skips ahead to the next group. This works, but in the absence of packet loss the differences with basic "group" congestion are minimal.