### PR TITLE
Manage uni stream priorities for warp congestion control

### DIFF
--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -327,7 +327,7 @@ uint64_t quicrq_handle_extra_repeat(quicrq_ctx_t* qr, uint64_t current_time);
  * The combination of group based + priorities will actually degrade performance, unless
  * the receiver selects the option "quicrq_subscribe_in_order_skip_to_group_ahead", which
  * cause receivers to process the next group as soon as reception begins, ignoring the tail
- * of the previous group. If that option s selected, performance is actually better than
+ * of the previous group. If that option is selected, performance is actually better than
  * the simple group based option.
  * 
  * The congestion options work for all transport modes (stream, datagram, warp), but in

--- a/include/quicrq.h
+++ b/include/quicrq.h
@@ -228,8 +228,9 @@ typedef struct st_quicrq_object_stream_consumer_ctx quicrq_object_stream_consume
 
 typedef enum {
     quicrq_subscribe_out_of_order = 0,
-    quicrq_subscribe_in_order,
-    quicrq_subscribe_in_order_skip_to_group_ahead
+    quicrq_subscribe_in_order = 1,
+    quicrq_subscribe_in_order_skip_to_group_ahead = 2,
+    quicrq_subscribe_order_max
 } quicrq_subscribe_order_enum;
 
 typedef enum {

--- a/lib/congestion.c
+++ b/lib/congestion.c
@@ -264,7 +264,7 @@ int quicrq_evaluate_datagram_congestion(quicrq_stream_ctx_t * stream_ctx, quicrq
             break;
         case quicrq_congestion_control_delay:
         default:
-            has_backlog = (current_time - media_ctx->current_fragment->cache_time) > delta_t_max;
+            has_backlog = (int64_t)(current_time - media_ctx->current_fragment->cache_time) > delta_t_max;
             should_skip = quicrq_congestion_check_per_cnx(stream_ctx->cnx_ctx,
                 media_ctx->current_fragment->flags, has_backlog, current_time);
             break;

--- a/lib/congestion.c
+++ b/lib/congestion.c
@@ -173,6 +173,7 @@ int quicrq_evaluate_stream_congestion(quicrq_fragment_publisher_context_t* media
     case quicrq_congestion_control_none:
         break;
     case quicrq_congestion_control_group:
+    case quicrq_congestion_control_group_p:
         if (media_ctx->current_offset > 0 || media_ctx->length_sent > 0) {
             should_skip = 0;
         }
@@ -220,6 +221,7 @@ int quicrq_evaluate_warp_congestion(quicrq_uni_stream_ctx_t* uni_stream_ctx, qui
         case quicrq_congestion_control_none:
             break;
         case quicrq_congestion_control_group:
+        case quicrq_congestion_control_group_p:
             /* compute group mode congestion control */
             should_skip = quicrq_compute_group_mode_congestion(media_ctx, uni_stream_ctx->current_group_id, uni_stream_ctx->current_object_id);
             break;
@@ -255,6 +257,7 @@ int quicrq_evaluate_datagram_congestion(quicrq_stream_ctx_t * stream_ctx, quicrq
         case quicrq_congestion_control_none:
             break;
         case quicrq_congestion_control_group:
+        case quicrq_congestion_control_group_p:
             /* compute group mode congestion control */
             should_skip = quicrq_compute_group_mode_congestion(media_ctx, media_ctx->current_fragment->group_id,
                 media_ctx->current_fragment->object_id);

--- a/lib/fragment.c
+++ b/lib/fragment.c
@@ -114,6 +114,10 @@ void quicrq_fragment_cache_progress(quicrq_fragment_cache_t* cache_ctx,
         cache_ctx->highest_object_id = fragment->object_id;
     }
 
+    if (fragment->flags > 0 && (cache_ctx->lowest_flags == 0 || cache_ctx->lowest_flags > fragment->flags)) {
+        cache_ctx->lowest_flags = fragment->flags;
+    }
+
     do {
         int is_expected = 0;
         fragment = (quicrq_cached_fragment_t*)quicrq_fragment_cache_node_value(next_fragment_node);

--- a/lib/object_consumer.c
+++ b/lib/object_consumer.c
@@ -101,6 +101,10 @@ int quicrq_media_object_bridge_ready(
                 /* then, mark this object as accepted */
                 ignore = 0;
             }
+            else if (group_id == bridge_ctx->next_group_id && object_id == bridge_ctx->next_object_id) {
+                /* accept "peek" if it is in sequence */
+                ignore = 0;
+            }
         }
         else {
             /* this object is both in sequence and with a larger

--- a/lib/quicrq_fragment.h
+++ b/lib/quicrq_fragment.h
@@ -48,6 +48,7 @@ typedef struct st_quicrq_fragment_cache_t {
     quicrq_cached_fragment_t* first_fragment; /* Fragments in order of arrival */
     quicrq_cached_fragment_t* last_fragment;
     picosplay_tree_t fragment_tree; /* Splay ordered by group_id/object_id/offset */
+    uint8_t lowest_flags;
     int is_feed_closed; /* Whether the data providing connection is closed. */
     uint64_t cache_delete_time;
 } quicrq_fragment_cache_t;

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -415,6 +415,7 @@ struct st_quicrq_uni_stream_ctx_t {
     uint64_t current_group_id;
     uint64_t current_object_id;
     uint64_t last_object_id; 
+    uint64_t stream_priority;
     /* UniStream state */
     quicrq_uni_stream_sending_state_enum send_state;
     quicrq_uni_stream_receive_state_enum receive_state;
@@ -476,6 +477,7 @@ struct st_quicrq_stream_ctx_t {
     quicrq_media_close_reason_enum close_reason;
     uint64_t close_error_code;
     /* Control flags */
+    uint8_t lowest_flags; /* Mark the lowest value of the flags field for media segments */
     unsigned int is_sender : 1;
     /* is_cache_real_time:
      * Indicates whether local cache management follows the "real time" logic,

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -660,11 +660,11 @@ int quicrq_congestion_warp_gs_test()
 
     spec.simulate_losses = 0;
     spec.congested_receiver = 0;
-    spec.max_drops = 62;
+    spec.max_drops = 60;
     spec.min_loss_flag = 0x82;
-    spec.average_delay_target = 530000;
-    spec.max_delay_target = 1120000;
-    spec.congestion_control_mode = quicrq_congestion_control_group;
+    spec.average_delay_target = 465000;
+    spec.max_delay_target = 755000;
+    spec.congestion_control_mode = quicrq_congestion_control_group_p;
     spec.subscribe_order = quicrq_subscribe_in_order_skip_to_group_ahead;
 
     ret = quicrq_congestion_test_one(1, quicrq_transport_mode_warp, &spec);


### PR DESCRIPTION
Adding a congestion control option for "Group based + priorities(3)". It is the same as group based, but in WARP transport mode, it also marks down the priorities of all but the last group (last uni stream). 

The combination of group based + priorities will actually degrade performance, unless the receiver selects the option "quicrq_subscribe_in_order_skip_to_group_ahead", which cause receivers to process the next group as soon as reception begins, ignoring the tail of the previous group. If that option is selected, performance is actually better than the simple group based option.

![image](https://user-images.githubusercontent.com/7464128/215391970-875db675-524b-43fd-b994-259753402e63.png)

The graph above shows the end to end delay per frame for the "basic warp" a "warp + priority" options. The use of priorities limits the possible delay increase caused by the large I-frames at the beginning of a UNI stream. This appears to be a very robust solution, with just one downside: in case of congestion, the delay will increase gradually, until the "jump ahead" at the beginning of the next GOP. That may not be the best visual experience. If we want to fix that, we probably need to design a combination of this "group based" strategy with the "delay base" strategy, to drop low priority frames and reduce delays without waiting for the next block.
