### PR TITLE
Add zero loss test of "warp with priorities"

### DIFF
--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -602,24 +602,29 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
-		TEST_METHOD(warp_congestion) {
+		TEST_METHOD(congestion_warp) {
 			int ret = quicrq_congestion_warp_test();
 
 			Assert::AreEqual(ret, 0);
 		}
 
-		TEST_METHOD(warp_congestion_g) {
+		TEST_METHOD(congestion_warp_g) {
 			int ret = quicrq_congestion_warp_g_test();
 
 			Assert::AreEqual(ret, 0);
 		}
 
-		TEST_METHOD(warp_congestion_gs) {
+		TEST_METHOD(congestion_warp_gs) {
 			int ret = quicrq_congestion_warp_gs_test();
 
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(congestion_warp_zero_s) {
+			int ret = quicrq_congestion_warp_zero_s_test();
+
+			Assert::AreEqual(ret, 0);
+		}
 		TEST_METHOD(warp_relay) {
 			int ret = quicrq_warp_relay_test();
 

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -117,9 +117,10 @@ static const quicrq_test_def_t test_table[] =
     { "warp_basic", quicrq_warp_basic_test },
     { "warp_basic_client", quicrq_warp_basic_client_test },
     { "warp_triangle", quicrq_triangle_warp_test },
-    { "warp_congestion", quicrq_congestion_warp_test },
-    { "warp_congestion_g", quicrq_congestion_warp_g_test },
-    { "warp_congestion_gs", quicrq_congestion_warp_gs_test },
+    { "congestion_warp", quicrq_congestion_warp_test },
+    { "congestion_warp_g", quicrq_congestion_warp_g_test },
+    { "congestion_warp_gs", quicrq_congestion_warp_gs_test },
+    { "congestion_warp_zero_s", quicrq_congestion_warp_zero_s_test },
     { "warp_relay", quicrq_warp_relay_test },
     { "warp_basic_loss", quicrq_warp_basic_loss_test },
     { "warp_relay_loss", quicrq_warp_relay_loss_test }

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -671,3 +671,23 @@ int quicrq_congestion_warp_gs_test()
 
     return ret;
 }
+
+int quicrq_congestion_warp_zero_s_test()
+{
+    quicrq_congestion_test_t spec = congestion_test_default;
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 0;
+    spec.min_loss_flag = 0xFF;
+    spec.congestion_mode = congestion_mode_zero;
+    spec.average_delay_target = 31000;
+    spec.max_delay_target = 155000;
+    spec.congestion_control_mode = quicrq_congestion_control_group_p;
+    spec.subscribe_order = quicrq_subscribe_in_order_skip_to_group_ahead;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_warp, &spec);
+
+    return ret;
+}

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -105,6 +105,7 @@ extern "C" {
     int quicrq_congestion_warp_test();
     int quicrq_congestion_warp_g_test();
     int quicrq_congestion_warp_gs_test();
+    int quicrq_congestion_warp_zero_s_test();
     int quicrq_warp_relay_test();
     int quicrq_warp_basic_loss_test();
     int quicrq_warp_relay_loss_test();


### PR DESCRIPTION
I just added this test to try debug the issue we observed during the MoQ interim.

Interestingly, the test passes on first attempt. This probably means that the issue at the MoQ interim is due to the decoder somehow falling behind the network, and creating hiccups. 