### PR TITLE
Add Rush support to QUICRQ

### DIFF
--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -644,5 +644,23 @@ namespace UnitTest
             Assert::AreEqual(ret, 0);
         }
 
+		TEST_METHOD(rush_basic) {
+			int ret = quicrq_rush_basic_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(rush_basic_client) {
+			int ret = quicrq_rush_basic_client_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(rush_basic_loss)
+		{
+			int ret = quicrq_rush_basic_loss_test();
+
+			Assert::AreEqual(ret, 0);
+		}
     };
 }

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -648,6 +648,7 @@ namespace UnitTest
 
 			Assert::AreEqual(ret, 0);
 		}
+
 		TEST_METHOD(warp_relay) {
 			int ret = quicrq_warp_relay_test();
 
@@ -688,6 +689,30 @@ namespace UnitTest
 
 		TEST_METHOD(rush_triangle) {
 			int ret = quicrq_triangle_rush_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(congestion_rush) {
+			int ret = quicrq_congestion_rush_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(congestion_rush_g) {
+			int ret = quicrq_congestion_rush_g_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(congestion_rush_gs) {
+			int ret = quicrq_congestion_rush_gs_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(congestion_rush_zero_s) {
+			int ret = quicrq_congestion_rush_zero_s_test();
 
 			Assert::AreEqual(ret, 0);
 		}

--- a/UnitTest/UnitTest.cpp
+++ b/UnitTest/UnitTest.cpp
@@ -471,6 +471,29 @@ namespace UnitTest
 			Assert::AreEqual(ret, 0);
 		}
 
+		TEST_METHOD(triangle_intent_rush) {
+			int ret = quicrq_triangle_intent_rush_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+		TEST_METHOD(triangle_intent_rush_nc) {
+			int ret = quicrq_triangle_intent_rush_nc_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(triangle_intent_rush_loss) {
+			int ret = quicrq_triangle_intent_rush_loss_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(triangle_intent_rush_next) {
+			int ret = quicrq_triangle_intent_rush_next_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
 		TEST_METHOD(pyramid_basic) {
 			int ret = quicrq_pyramid_basic_test();
 
@@ -659,6 +682,12 @@ namespace UnitTest
 		TEST_METHOD(rush_basic_loss)
 		{
 			int ret = quicrq_rush_basic_loss_test();
+
+			Assert::AreEqual(ret, 0);
+		}
+
+		TEST_METHOD(rush_triangle) {
+			int ret = quicrq_triangle_rush_test();
 
 			Assert::AreEqual(ret, 0);
 		}

--- a/lib/fragment.c
+++ b/lib/fragment.c
@@ -1081,6 +1081,24 @@ uint64_t quicrq_fragment_get_object_count(quicrq_fragment_cache_t* cache_ctx, ui
     return nb_objects;
 }
 
+/* Get the object flags, or zero if the object is not available*/
+uint8_t quicrq_fragment_get_flags(quicrq_fragment_cache_t* cache_ctx, uint64_t group_id, uint64_t object_id)
+{
+    quicrq_cached_fragment_t key = { 0 };
+    picosplay_node_t* fragment_node;
+    uint8_t flags = 0;
+    key.group_id = group_id;
+    key.object_id = object_id;
+    key.offset = 0;
+    fragment_node = picosplay_find(&cache_ctx->fragment_tree, &key);
+    if (fragment_node != NULL) {
+        quicrq_cached_fragment_t* fragment_state =
+            (quicrq_cached_fragment_t*)quicrq_fragment_cache_node_value(fragment_node);
+        flags = fragment_state->flags;
+    }
+    return flags;
+}
+
 /* Copy a full object from the cache.
  * - return the size of the object if it is completely received
  * - returns 0 if the object is not yet received

--- a/lib/quicrq_fragment.h
+++ b/lib/quicrq_fragment.h
@@ -275,6 +275,8 @@ void quicrq_fragment_notify_final_to_control(quicrq_fragment_cache_t* cache_ctx,
 
 uint64_t quicrq_fragment_get_object_count(quicrq_fragment_cache_t* cache_ctx, uint64_t group_id);
 
+uint8_t quicrq_fragment_get_flags(quicrq_fragment_cache_t* cache_ctx, uint64_t group_id, uint64_t object_id);
+
 size_t quicrq_fragment_object_copy(quicrq_fragment_cache_t* cache_ctx, uint64_t group_id, uint64_t object_id, uint64_t* nb_objects_previous_group, uint8_t* flags, uint8_t* buffer);
 
 void* quicrq_fragment_publisher_subscribe(quicrq_fragment_cache_t* cache_ctx, quicrq_stream_ctx_t* stream_ctx);

--- a/lib/quicrq_internal.h
+++ b/lib/quicrq_internal.h
@@ -449,6 +449,7 @@ struct st_quicrq_stream_ctx_t {
     uint64_t final_group_id;
     uint64_t final_object_id;
     uint64_t next_warp_group_id; /* group_id to create next in warp mode */
+    uint64_t next_rush_object_id; /* in rush, next object to send in this group */
     /* Control of datagrams sent for that media
      * We only keep track of fragments that are above the horizon.
      * The one below horizon are already acked, or otherwise forgotten.
@@ -618,11 +619,11 @@ quicrq_uni_stream_ctx_t* quicrq_find_or_create_uni_stream(
     quicrq_cnx_ctx_t* cnx_ctx,
     quicrq_stream_ctx_t* stream_ctx,
     int should_create);
-
+#if 0
 quicrq_uni_stream_ctx_t* quicrq_find_uni_stream_for_group(
         quicrq_stream_ctx_t* control_stream_ctx,
         uint64_t group_id);
-
+#endif
 void quicrq_chain_uni_stream_to_control_stream(quicrq_uni_stream_ctx_t* uni_stream_ctx, quicrq_stream_ctx_t* stream_ctx);
 
 

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -92,6 +92,10 @@ static const quicrq_test_def_t test_table[] =
     { "triangle_intent_warp_nc", quicrq_triangle_intent_warp_nc_test },
     { "triangle_intent_warp_loss", quicrq_triangle_intent_warp_loss_test },
     { "triangle_intent_warp_next", quicrq_triangle_intent_warp_next_test },
+    { "triangle_intent_rush", quicrq_triangle_intent_rush_test },
+    { "triangle_intent_rush_nc", quicrq_triangle_intent_rush_nc_test },
+    { "triangle_intent_rush_loss", quicrq_triangle_intent_rush_loss_test },
+    { "triangle_intent_rush_next", quicrq_triangle_intent_rush_next_test },
     { "pyramid_basic", quicrq_pyramid_basic_test },
     { "pyramid_datagram", quicrq_pyramid_datagram_test },
     { "pyramid_datagram_loss", quicrq_pyramid_datagram_loss_test },
@@ -126,7 +130,8 @@ static const quicrq_test_def_t test_table[] =
     { "warp_relay_loss", quicrq_warp_relay_loss_test },
     { "rush_basic", quicrq_rush_basic_test },
     { "rush_basic_client", quicrq_rush_basic_client_test },
-    { "rush_basic_loss", quicrq_rush_basic_loss_test }
+    { "rush_basic_loss", quicrq_rush_basic_loss_test },
+    { "rush_triangle", quicrq_triangle_rush_test }
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(quicrq_test_def_t);

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -131,7 +131,11 @@ static const quicrq_test_def_t test_table[] =
     { "rush_basic", quicrq_rush_basic_test },
     { "rush_basic_client", quicrq_rush_basic_client_test },
     { "rush_basic_loss", quicrq_rush_basic_loss_test },
-    { "rush_triangle", quicrq_triangle_rush_test }
+    { "rush_triangle", quicrq_triangle_rush_test },
+    { "congestion_rush", quicrq_congestion_rush_test },
+    { "congestion_rush_g", quicrq_congestion_rush_g_test },
+    { "congestion_rush_gs", quicrq_congestion_rush_gs_test },
+    { "congestion_rush_zero_s", quicrq_congestion_rush_zero_s_test }
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(quicrq_test_def_t);

--- a/src/quicrq_t.c
+++ b/src/quicrq_t.c
@@ -123,7 +123,10 @@ static const quicrq_test_def_t test_table[] =
     { "congestion_warp_zero_s", quicrq_congestion_warp_zero_s_test },
     { "warp_relay", quicrq_warp_relay_test },
     { "warp_basic_loss", quicrq_warp_basic_loss_test },
-    { "warp_relay_loss", quicrq_warp_relay_loss_test }
+    { "warp_relay_loss", quicrq_warp_relay_loss_test },
+    { "rush_basic", quicrq_rush_basic_test },
+    { "rush_basic_client", quicrq_rush_basic_client_test },
+    { "rush_basic_loss", quicrq_rush_basic_loss_test }
 };
 
 static size_t const nb_tests = sizeof(test_table) / sizeof(quicrq_test_def_t);

--- a/tests/basic_test.c
+++ b/tests/basic_test.c
@@ -713,6 +713,24 @@ int quicrq_warp_basic_loss_test()
     return quicrq_basic_test_one(1, quicrq_transport_mode_warp, 0x7080, 0, 0, 0, 0);
 }
 
+/* Basic rush test. Same as the basic test, but using rush instead of streams. */
+int quicrq_rush_basic_test()
+{
+    return quicrq_basic_test_one(1, quicrq_transport_mode_rush, 0, 0, 0, 0, 0);
+}
+
+/* Basic client test for warp mode */
+int quicrq_rush_basic_client_test()
+{
+    return quicrq_basic_test_one(1, quicrq_transport_mode_rush, 0, 1, 0, 0, 0);
+}
+
+/* Datagram test, with forced packet losses when using warp mode*/
+int quicrq_rush_basic_loss_test()
+{
+    return quicrq_basic_test_one(1, quicrq_transport_mode_rush, 0x7080, 0, 0, 0, 0);
+}
+
 
 int quicrq_get_addr_test()
 {

--- a/tests/congestion_test.c
+++ b/tests/congestion_test.c
@@ -691,3 +691,79 @@ int quicrq_congestion_warp_zero_s_test()
 
     return ret;
 }
+
+
+int quicrq_congestion_rush_test()
+{
+    quicrq_congestion_test_t spec = congestion_test_default;
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 80;
+    spec.min_loss_flag = 0x82;
+    spec.average_delay_target = 210000;
+    spec.max_delay_target = 600000;
+    spec.congestion_control_mode = quicrq_congestion_control_delay;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_rush, &spec);
+
+    return ret;
+}
+
+int quicrq_congestion_rush_g_test()
+{
+    quicrq_congestion_test_t spec = congestion_test_default;
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 61;
+    spec.min_loss_flag = 0x82;
+    spec.average_delay_target = 550000;
+    spec.max_delay_target = 1500000;
+    spec.congestion_control_mode = quicrq_congestion_control_group;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_rush, &spec);
+
+    return ret;
+}
+
+int quicrq_congestion_rush_gs_test()
+{
+    quicrq_congestion_test_t spec = congestion_test_default;
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 76;
+    spec.min_loss_flag = 0x82;
+    spec.average_delay_target = 500000;
+    spec.max_delay_target = 1150000;
+    spec.congestion_control_mode = quicrq_congestion_control_group_p;
+    spec.subscribe_order = quicrq_subscribe_in_order_skip_to_group_ahead;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_rush, &spec);
+
+    return ret;
+}
+
+int quicrq_congestion_rush_zero_s_test()
+{
+    quicrq_congestion_test_t spec = congestion_test_default;
+    int ret = 0;
+
+    spec.simulate_losses = 0;
+    spec.congested_receiver = 0;
+    spec.max_drops = 0;
+    spec.min_loss_flag = 0xFF;
+    spec.congestion_mode = congestion_mode_zero;
+    spec.average_delay_target = 31000;
+    spec.max_delay_target = 155000;
+    spec.congestion_control_mode = quicrq_congestion_control_group_p;
+    spec.subscribe_order = quicrq_subscribe_in_order_skip_to_group_ahead;
+
+    ret = quicrq_congestion_test_one(1, quicrq_transport_mode_rush, &spec);
+
+    return ret;
+}

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -112,6 +112,11 @@ extern "C" {
     int quicrq_rush_basic_test();
     int quicrq_rush_basic_client_test();
     int quicrq_rush_basic_loss_test();
+    int quicrq_triangle_rush_test();
+    int quicrq_triangle_intent_rush_test();
+    int quicrq_triangle_intent_rush_nc_test();
+    int quicrq_triangle_intent_rush_loss_test();
+    int quicrq_triangle_intent_rush_next_test();
 
 #ifdef __cplusplus
 }

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -109,6 +109,9 @@ extern "C" {
     int quicrq_warp_relay_test();
     int quicrq_warp_basic_loss_test();
     int quicrq_warp_relay_loss_test();
+    int quicrq_rush_basic_test();
+    int quicrq_rush_basic_client_test();
+    int quicrq_rush_basic_loss_test();
 
 #ifdef __cplusplus
 }

--- a/tests/quicrq_tests.h
+++ b/tests/quicrq_tests.h
@@ -106,6 +106,10 @@ extern "C" {
     int quicrq_congestion_warp_g_test();
     int quicrq_congestion_warp_gs_test();
     int quicrq_congestion_warp_zero_s_test();
+    int quicrq_congestion_rush_test();
+    int quicrq_congestion_rush_g_test();
+    int quicrq_congestion_rush_gs_test();
+    int quicrq_congestion_rush_zero_s_test();
     int quicrq_warp_relay_test();
     int quicrq_warp_basic_loss_test();
     int quicrq_warp_relay_loss_test();

--- a/tests/triangle_test.c
+++ b/tests/triangle_test.c
@@ -423,6 +423,16 @@ int quicrq_triangle_warp_test()
     return ret;
 }
 
+int quicrq_triangle_rush_test()
+{
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_rush, &spec);
+
+    return ret;
+}
+
+
 /* The start point test verifies what happens if a source does not start
  * at Group=0, Object=0. That would be, for example, a source resuming
  * after a hiatus. This test will have to be rewritten after we change
@@ -616,6 +626,46 @@ int quicrq_triangle_intent_warp_next_test()
     spec.test_cache_clear = 1;
     spec.test_intent = 2;
     int ret = quicrq_triangle_test_one(quicrq_transport_mode_warp, &spec);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_rush_test()
+{
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_rush, &spec);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_rush_nc_test()
+{
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_rush, &spec);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_rush_loss_test()
+{
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.simulate_losses = 0x7080;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 1;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_rush, &spec);
+
+    return ret;
+}
+
+int quicrq_triangle_intent_rush_next_test()
+{
+    quicrq_triangle_test_spec_t spec = triangle_test_default;
+    spec.test_cache_clear = 1;
+    spec.test_intent = 2;
+    int ret = quicrq_triangle_test_one(quicrq_transport_mode_rush, &spec);
 
     return ret;
 }


### PR DESCRIPTION
This PR implements Rush transport mode in QUICRQ, and adds the required tests to verify behavior. The implementation broadly follows the Rush spec, with a couple particularities:

* as in Rush, each object is sent in a dedicated unidir stream.
* the stream priority is derived from the stream flags
* the stream priorities are set to FIFO, instead of round robin in Warp. the round robin variant was tried, but causes really bad delays in case of congestion.
* the Rush streams are formatted just like Warp stream, with a group header followed by an object header. This is a bit suboptimal, as a single header is needed, but it is good enough to compare the performance of multiple variants.

The frame delays for both Rush and Warp are worse than datagrams, or even single streams. This ought to be addressed in a separate PR, implementing pipelining of objects in relays instead of only relaying whole objects.